### PR TITLE
fix: add missing implement.md to command_files list

### DIFF
--- a/setup/components/commands.py
+++ b/setup/components/commands.py
@@ -32,6 +32,7 @@ class CommandsComponent(Component):
             "estimate.md",
             "explain.md",
             "git.md",
+            "implement.md",
             "improve.md",
             "index.md",
             "load.md",


### PR DESCRIPTION
The /sc:implement command was not being installed because implement.md was missing from the command_files list in CommandsComponent.

This fix ensures all 16 command files are properly installed:
- analyze.md, build.md, cleanup.md, design.md, document.md
- estimate.md, explain.md, git.md, implement.md, improve.md
- index.md, load.md, spawn.md, task.md, test.md, troubleshoot.md

Fixes: Missing /sc:implement command after installation
Issue: Command exists in SuperClaude/Commands/ but wasn't copied during install