### PR TITLE
Fix: remove non-breaking space (U+00A0) from __main__.py

### DIFF
--- a/SuperClaude/__main__.py
+++ b/SuperClaude/__main__.py
@@ -203,7 +203,7 @@ def main() -> int:
         operations = register_operation_parsers(subparsers, global_parser)
         args = parser.parse_args()
         # === PATCH to fix install_dir mismatch for Microsoft account ===
-  
+
         actual_home = Path.home()
 
         # If SuperClaude thinks install_dir is not your real user folder, correct it


### PR DESCRIPTION
### Fix: Remove non-breaking space (U+00A0) in __main__.py

There was a syntax error caused by an invisible non-breaking space character on line 206.

This PR removes that character and replaces it with a regular space.