### PR TITLE
fix:non-breaking space (U+00A0) installation error

### DIFF
--- a/SuperClaude/__main__.py
+++ b/SuperClaude/__main__.py
@@ -203,14 +203,14 @@ def main() -> int:
         operations = register_operation_parsers(subparsers, global_parser)
         args = parser.parse_args()
         # === PATCH to fix install_dir mismatch for Microsoft account ===
-  
-        actual_home = Path.home()
+  
+        actual_home = Path.home()
 
-        # If SuperClaude thinks install_dir is not your real user folder, correct it
-        if args.install_dir and not str(args.install_dir).startswith(str(actual_home)):
-            print(f"[INFO] Overriding incorrect install path: {args.install_dir} → {actual_home}")
-            args.install_dir = actual_home
-        # === END PATCH ===
+        # If SuperClaude thinks install_dir is not your real user folder, correct it
+        if args.install_dir and not str(args.install_dir).startswith(str(actual_home)):
+            print(f"[INFO] Overriding incorrect install path: {args.install_dir} → {actual_home}")
+            args.install_dir = actual_home
+        # === END PATCH ===
 
         # No operation provided? Show help manually unless in quiet mode
         if not args.operation:


### PR DESCRIPTION
While installing on my windows machine, I was getting error
```
python -m SuperClaude install
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 159, in _get_module_details
  File "<frozen importlib._bootstrap_external>", line 1160, in get_code
  File "<frozen importlib._bootstrap_external>", line 1090, in source_to_code
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "D:\prac_repo\AI\SuperClaude\SuperClaude\__main__.py", line 206
     
    ^
SyntaxError: invalid non-printable character U+00A0
```
