### PR TITLE
fix: correct playwright MCP package name typo

### DIFF
--- a/setup/components/mcp.py
+++ b/setup/components/mcp.py
@@ -43,7 +43,7 @@ class MCPComponent(Component):
             "playwright": {
                 "name": "playwright",
                 "description": "Cross-browser E2E testing and automation",
-                "npm_package": "@playright/mcp@latest",
+                "npm_package": "@playwright/mcp@latest",
                 "required": False
             }
         }


### PR DESCRIPTION
## Summary
- Fix critical typo in playwright MCP server configuration
- Change @playright/mcp to @playwright/mcp in setup/components/mcp.py
- Prevents MCP installation failures due to package not found errors

## Test plan
- [x] Verify package name is correctly spelled as @playwright/mcp
- [x] Confirm no other playwright typos exist in codebase
- [x] Test MCP installation process works with corrected package name

🤖 Generated with [Claude Code](https://claude.ai/code)