### PR TITLE
Fix installation failures on Windows systems with alias usernames

### DIFF
--- a/setup/utils/security.py
+++ b/setup/utils/security.py
@@ -427,11 +427,17 @@ class SecurityValidator:
                             errors.append("Installation to junction points or symbolic links is not allowed for security")
                             return False, errors
                         
-                        # Additional validation: verify it's in a user profile directory structure
-                        # Only check if it looks like a Windows path (contains drive letter)
+                        # Additional validation: verify it's in the current user's profile directory
+                        # Use actual home directory comparison instead of username-based path construction
                         if ':' in abs_target_str and '\\users\\' in abs_target_str:
-                            current_user = os.environ.get('USERNAME', '')
-                            if current_user and f'\\users\\{current_user.lower()}\\' not in abs_target_str:
+                            try:
+                                # Check if target is within the user's actual home directory
+                                home_path = Path.home()
+                                abs_target.relative_to(home_path)
+                                # Path is valid - within user's home directory
+                            except ValueError:
+                                # Path is outside user's home directory
+                                current_user = os.environ.get('USERNAME', home_path.name)
                                 errors.append(f"Installation must be in current user's directory ({current_user})")
                                 return False, errors
                     


### PR DESCRIPTION
# Fix Windows user directory validation for aliased usernames

## 🐛 Problem Description

The current security validation in `setup/utils/security.py` fails when Windows users have an alias username that doesn't match their profile directory name. This occurs because the validation constructs the expected path using `%USERNAME%` but compares it against the actual profile directory path.

### Issue Details
- **Error**: `Installation must be in current user's directory (A)`
- **Root Cause**: Username alias `A` != profile directory `User` 
- **Affected Code**: `SecurityValidator.validate_installation_target()` line ~390

### Example Scenario
```
USERNAME=A
USERPROFILE=C:\Users\User
Target Path=C:\Users\User\.claude

Expected by validation: \users\a\
Actual path contains:    \users\user\
Result:  Validation fails
```

## 🔧 Proposed Solution

Replace the username-based path construction with actual home directory comparison

## 📋Changes Made
File: `setup/utils/security.py`
Lines ~385-395 in `validate_installation_target()` method:**

## ✅ Benefits

1. **Fixes alias username issue**: Works with any username/profile directory combination
2. **More accurate validation**: Uses actual filesystem paths instead of environment variables
3. **Maintains security**: Still prevents installation outside user directory
4. **Better error messages**: Shows actual username when available
5. **Cross-platform compatibility**: `Path.home()` works on all platforms

## 🧪 Test Cases

### Test Case 1: Alias Username (Current Bug)
```python
# Environment
USERNAME=A
USERPROFILE=C:\Users\User

# Test
target = Path("C:/Users/User/.claude")
result, errors = SecurityValidator.validate_installation_target(target)

# (currently fails)
assert result == True, "Expected success"
```

### Test Case 2: Matching Username (Currently Works)
```python
# Environment  
USERNAME=User
USERPROFILE=C:\Users\User

# Test
target = Path("C:/Users/User/.claude")  
result, errors = SecurityValidator.validate_installation_target(target)

assert result == True, "Expected success"
```

### Test Case 3: Outside User Directory (Should Fail)
```python
# Test
target = Path("C:/Users/OtherUser/.claude")
result, errors = SecurityValidator.validate_installation_target(target)

# Expected: Failure
assert result == False
assert "current user's directory" in errors[0]
```
## Related Issues
#190
