### PR TITLE
refactor: remove duplicate import sys in __main__.py

### DIFF
--- a/SuperClaude/__main__.py
+++ b/SuperClaude/__main__.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import Dict, Callable
 
 # Add the 'setup' directory to the Python import path (with deprecation-safe logic)
-import sys
 
 try:
     # Python 3.9+ preferred modern way


### PR DESCRIPTION
  ## Description
  Remove redundant `import sys` statement in SuperClaude/__main__.py that was imported twice.

  ## Changes
  - Removed duplicate `import sys` at line 22
  - The sys module is already imported at line 14 with other standard library imports

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update

  ## Testing
  - [x] Code still imports and runs correctly
  - [x] No functionality is affected by this change

  ## Additional Notes
  This is a minor code cleanup that improves code quality by removing redundant imports.