### PR TITLE
fix: Add missing quote and comma to package.json version field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bifrost_inc/superclaude",
-  "version": "4.1.4
+  "version": "4.1.4",
   "description": "SuperClaude Framework NPM wrapper - Official Node.js wrapper for the Python SuperClaude package. Enhances Claude Code with specialized commands and AI development tools.",
   "scripts": {
     "postinstall": "node ./bin/install.js",


### PR DESCRIPTION
## Summary
- Fixed unterminated string literal error in package.json
- Added missing closing quote and comma to version field on line 3

## Changes
- "version": "4.1.4 → "version": "4.1.4",

## Test Plan
- [x] Verified JSON syntax is now valid
- [x] Package.json can be parsed without errors

This was causing a JSON parsing error that prevented proper package installation and management.