### PR TITLE
fix: Correct Tavily MCP package name in documentation

### DIFF
--- a/Docs/User-Guide/mcp-servers.md
+++ b/Docs/User-Guide/mcp-servers.md
@@ -185,7 +185,7 @@ export TAVILY_API_KEY="tvly-your_api_key_here"
     },
     "tavily": {
       "command": "npx",
-      "args": ["-y", "@tavily/mcp@latest"],
+      "args": ["-y", "tavily-mcp@latest"],
       "env": {"TAVILY_API_KEY": "${TAVILY_API_KEY}"}
     }
   }


### PR DESCRIPTION
The documentation incorrectly referenced @tavily/mcp, which doesn't exist. The correct package name is tavily-mcp, as confirmed by:
- The setup script already uses tavily-mcp@0.1.2
- NPM registry shows tavily-mcp exists
- @tavily/mcp returns 404 not found

This fix ensures users can successfully configure Tavily MCP server by following the documentation.