### PR TITLE
fix(orchestration): add WebFetch auto-trigger for infrastructure configuration

### DIFF
--- a/SuperClaude/Modes/MODE_Orchestration.md
+++ b/SuperClaude/Modes/MODE_Orchestration.md
@@ -25,6 +25,23 @@
 | Documentation | Context7 MCP | Web search |
 | Browser testing | Playwright MCP | Unit tests |
 | Multi-file edits | MultiEdit | Sequential Edits |
+| Infrastructure config | WebFetch (official docs) | Assumption-based (❌ forbidden) |
+
+## Infrastructure Configuration Validation
+
+**Critical Rule**: Infrastructure and technical configuration changes MUST consult official documentation before making recommendations.
+
+**Auto-Triggers for Infrastructure Tasks**:
+- **Keywords**: Traefik, nginx, Apache, HAProxy, Caddy, Envoy, Docker, Kubernetes, Terraform, Ansible
+- **File Patterns**: `*.toml`, `*.conf`, `traefik.yml`, `nginx.conf`, `*.tf`, `Dockerfile`
+- **Required Actions**:
+  1. **WebFetch official documentation** before any technical recommendation
+  2. Activate MODE_DeepResearch for infrastructure investigation
+  3. BLOCK assumption-based configuration changes
+
+**Rationale**: Infrastructure misconfiguration can cause production outages. Always verify against official documentation (e.g., Traefik docs for port configuration, nginx docs for proxy settings).
+
+**Enforcement**: This rule enforces the "Evidence > assumptions" principle from PRINCIPLES.md for infrastructure operations.
 
 ## Resource Management
 


### PR DESCRIPTION
## Problem
Infrastructure configuration changes (e.g., Traefik port settings) were being made based on assumptions without consulting official documentation, violating the "Evidence > assumptions" principle in PRINCIPLES.md.

## Solution
- Added **Infrastructure Configuration Validation** section to MODE_Orchestration.md
- Auto-triggers **WebFetch** for infrastructure tools (Traefik, nginx, Docker, Kubernetes, etc.)
- Enforces **MODE_DeepResearch** activation for investigation
- **BLOCKS** assumption-based configuration changes

## Changes
- Added infrastructure config row to Tool Selection Matrix
- Added new section with auto-trigger rules for infrastructure keywords and file patterns
- Includes rationale and enforcement reference to PRINCIPLES.md

## Testing
Verified WebFetch successfully retrieves Traefik official documentation (confirmed port 80 as default for web entrypoint).

## Impact
Prevents production outages from infrastructure misconfiguration by ensuring all technical recommendations are backed by official documentation.