### PR TITLE
Fix ModuleNotFoundError in PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -122,7 +122,7 @@ jobs:
         echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
         echo "| Target | ${{ github.event_name == 'release' && 'PyPI (Production)' || github.event.inputs.target || 'TestPyPI' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Trigger | ${{ github.event_name }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Version | $(python -c 'from SuperClaude import __version__; print(__version__)') |" >> $GITHUB_STEP_SUMMARY
+        echo "| Version | $(python -c 'from superclaude import __version__; print(__version__)') |" >> $GITHUB_STEP_SUMMARY
         echo "| Commit | ${{ github.sha }} |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
@@ -161,8 +161,8 @@ jobs:
         # Test basic import
         python -c "
         import superclaude
-        print(f'✅ Successfully imported SuperClaude v{SuperClaude.__version__}')
-        
+        print(f'✅ Successfully imported SuperClaude v{superclaude.__version__}')
+
         # Test CLI entry point
         import subprocess
         result = subprocess.run(['SuperClaude', '--version'], capture_output=True, text=True)


### PR DESCRIPTION
## Problem

The v4.1.6 PyPI publish workflow is failing with `ModuleNotFoundError: No module named 'SuperClaude'`.

**Failed workflow runs:**
- 5 consecutive failures since v4.1.6 release
- See: https://github.com/SuperClaude-Org/SuperClaude_Framework/actions/workflows/publish-pypi.yml

**Root cause:**
v4.1.6 partially fixed the module import but missed updating variable references:
- ✅ Changed `import SuperClaude` → `import superclaude` 
- ❌ Left `SuperClaude.__version__` unchanged (should be `superclaude.__version__`)

## Changes

Fixed 2 remaining incorrect module references:

1. **Line 125** (deployment summary step):
   ```diff
   - from SuperClaude import __version__
   + from superclaude import __version__
   ```

2. **Line 164** (test installation step):
   ```diff
   - SuperClaude.__version__
   + superclaude.__version__
   ```

## Context

- **Package name** (PyPI): `SuperClaude` (used for `pip install SuperClaude`)
- **Module name** (Python): `superclaude` (used for `import superclaude`)

## Testing

After this fix, the workflow should:
- ✅ Successfully verify version consistency
- ✅ Build and publish to PyPI
- ✅ Complete deployment summary generation
- ✅ Pass installation tests

## Impact

This will unblock v4.1.6 publication to PyPI, allowing users to upgrade via `pipx upgrade SuperClaude`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>