### PR TITLE
fix: update airis mcp gateway installer

### DIFF
--- a/docs/Development/install-process-analysis.md
+++ b/docs/Development/install-process-analysis.md
@@ -428,7 +428,7 @@ pytest tests/performance/ -v
 
 # 3. User Acceptance
 - Install with --recommended
-- Verify airis-mcp-gateway works
+- Verify airis-mcp-gateway works (using https://github.com/agiletec-inc/airis-mcp-gateway)
 - Verify PM Agent can delegate to sub-agents
 - Verify no warnings or errors
 


### PR DESCRIPTION
## 概要
- SuperClaude の MCP インストーラで参照していた旧 airis-mcp-gateway URL を agiletec-inc リポジトリに更新
- installer 実装を公式手順（git clone → make install-claude）ベースに変更
- ドキュメントのテスト手順も新 URL へ差し替え

## 動作確認
- `uv run python -m pytest` ※ `setup.components.mcp_docs` が存在せず収集時に ModuleNotFoundError。テスト環境要確認
