### PR TITLE
docs: add AIRIS MCP Gateway as recommended installation method

### DIFF
--- a/docs/reference/mcp-server-guide.md
+++ b/docs/reference/mcp-server-guide.md
@@ -16,6 +16,43 @@
 - **Morphllm**: Pattern-based code editing with token optimization
 - **Serena**: Semantic code understanding and project memory
 
+### Recommended: AIRIS MCP Gateway (Unified Installation)
+
+Instead of installing MCP servers individually, use **AIRIS MCP Gateway** for a unified experience:
+
+**Benefits:**
+- 25+ MCP servers in one endpoint
+- 90% token reduction at startup (lazy loading)
+- Zero-config experience with Settings UI
+- Includes: Tavily, Serena, Mindbase, Context7, Sequential, and more
+
+**Quick Install:**
+```bash
+# 1. Clone and start the gateway
+git clone https://github.com/agiletec-inc/airis-mcp-gateway.git
+cd airis-mcp-gateway
+cp .env.example .env
+docker compose up -d
+
+# 2. Register with Claude Code
+claude mcp add --transport http airis-mcp-gateway http://api.gateway.localhost:9400/api/v1/mcp
+
+# 3. Access Settings UI (optional)
+open http://ui.gateway.localhost:5273
+```
+
+**Requirements:**
+- Docker and Docker Compose
+- API keys for specific services (Tavily, etc.) - configure via Settings UI
+
+For detailed setup, see: https://github.com/agiletec-inc/airis-mcp-gateway
+
+---
+
+### Individual Server Installation (Alternative)
+
+If you prefer installing servers individually:
+
 **Server Requirements:**
 - Node.js 16.0.0 or higher
 - npm or yarn package manager

--- a/src/superclaude/cli/install_mcp.py
+++ b/src/superclaude/cli/install_mcp.py
@@ -286,6 +286,20 @@ def list_available_servers():
     """List all available MCP servers."""
     click.echo("📋 Available MCP Servers:\n")
 
+    # Recommend AIRIS MCP Gateway first
+    click.echo("━━━ Recommended: Unified Gateway ━━━\n")
+    click.echo("   airis-mcp-gateway         ⭐ RECOMMENDED")
+    click.echo("      25+ MCP servers in one endpoint (90% token reduction)")
+    click.echo("      Includes: Tavily, Serena, Mindbase, Context7, Sequential, etc.")
+    click.echo()
+    click.echo("   Install:")
+    click.echo("      git clone https://github.com/agiletec-inc/airis-mcp-gateway.git")
+    click.echo("      cd airis-mcp-gateway && docker compose up -d")
+    click.echo("      claude mcp add --transport http airis-mcp-gateway \\")
+    click.echo("        http://api.gateway.localhost:9400/api/v1/mcp")
+    click.echo()
+    click.echo("━━━ Individual Servers (Alternative) ━━━\n")
+
     for server_key, server_info in MCP_SERVERS.items():
         name = server_info["name"]
         description = server_info["description"]
@@ -302,7 +316,8 @@ def list_available_servers():
         click.echo(f"      {description}{api_key_note}")
         click.echo()
 
-    click.echo(f"Total: {len(MCP_SERVERS)} servers available")
+    click.echo(f"Total: {len(MCP_SERVERS)} individual servers available")
+    click.echo("\n💡 Tip: Use airis-mcp-gateway for unified installation with token optimization")
 
 
 def install_mcp_servers(


### PR DESCRIPTION
## Summary

Fixes #457

- Add AIRIS MCP Gateway section to `mcp-server-guide.md` with quick install steps
- Update `install_mcp.py` to recommend airis-mcp-gateway first when listing servers
- Provide clear Docker Compose installation instructions
- Include correct repository URL: https://github.com/agiletec-inc/airis-mcp-gateway

## Problem

Users were confused about AIRIS MCP Gateway installation (#457) because:
1. The old uvx-based installation was incorrect (airis-mcp-gateway is Docker Compose, not Python)
2. The repository URL was wrong (`oraios/` instead of `agiletec-inc/`)
3. No clear documentation existed for the recommended installation method

## Solution

- Document AIRIS MCP Gateway as the **recommended** unified installation method
- Provide step-by-step Docker Compose instructions
- Keep individual server installation as an alternative option

## Test plan

- [ ] Run `superclaude mcp --list` and verify airis-mcp-gateway is shown as recommended
- [ ] Verify documentation links are correct
- [ ] Test Docker Compose installation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)