### PR TITLE
Fix AIRIS MCP Gateway installer bugs

### DIFF
--- a/src/superclaude/cli/install_mcp.py
+++ b/src/superclaude/cli/install_mcp.py
@@ -291,7 +291,9 @@ TAVILY_API_KEY=
 """
         env_file.write_text(env_content)
         click.echo(f"   ✅ Created .env file at {env_file}")
-        click.echo(f"   💡 Edit {env_file} to customize settings (e.g., add TAVILY_API_KEY)")
+        click.echo(
+            f"   💡 Edit {env_file} to customize settings (e.g., add TAVILY_API_KEY)"
+        )
     else:
         click.echo("   ✅ .env file already exists")
 


### PR DESCRIPTION
## Summary

Fixes 5 bugs in the AIRIS MCP Gateway installer (`superclaude mcp --servers airis-mcp-gateway`) that leave the gateway non-functional after installation:

- **mcp-config.json never created**: The installer downloads `docker-compose.yml` but never creates `mcp-config.json` (which the compose file bind-mounts at `/app/mcp-config.json:ro`). Docker creates an empty file, so the gateway starts with zero backend servers. Added download with fallback to a minimal default config.
- **Wrong `claude mcp add` format for SSE transport**: Used `npx mcp-remote` (stdio proxy) instead of direct SSE URL. Claude Code natively supports SSE transport — fixed to pass URL directly.
- **Missing `.env` file**: Docker Compose uses env vars (`HOST_WORKSPACE_DIR`, `TAVILY_API_KEY`, `MINDBASE_URL`) but the installer never created a `.env` file. `HOST_WORKSPACE_DIR` defaulted to `~/github` which Docker doesn't expand. Now creates `.env` with absolute paths.
- **`mindbase` crashes gateway at startup**: Template enables mindbase with a wrong subdirectory path (`#subdirectory=mcp` vs actual `apps/mcp-server`), making the gateway go unhealthy. Disabled alongside `airis-agent` since both require external setup.
- **No post-startup health check**: Installer said "containers started" without verifying. Added health polling (6 attempts, 5s intervals) to confirm the gateway is actually healthy.

## Changes

Single file: `src/superclaude/cli/install_mcp.py`

**Commit 1** (`c90943f`):
1. Added `mcp_config_url` to `AIRIS_GATEWAY` config dict
2. Added mcp-config.json download step (with fallback to minimal default config)
3. Auto-disables `airis-agent` server in downloaded template
4. Fixed `claude mcp add` to use correct SSE format (URL directly, not via `npx mcp-remote`)

**Commit 2** (`b4ba46b`):
5. Create `.env` file with `HOST_WORKSPACE_DIR` set to absolute path (no tilde)
6. Added `mindbase` to `servers_to_disable` list
7. Added post-startup health check polling
8. Updated dry_run output to mention `.env` creation

## Test plan

- [x] Run `superclaude mcp --servers airis-mcp-gateway --dry-run` and verify output mentions `.env` creation
- [x] Run full install on a clean machine (no existing `~/.superclaude/airis-mcp-gateway/`)
- [x] Verify `.env` file has absolute path for `HOST_WORKSPACE_DIR` (no tilde)
- [x] Verify `mcp-config.json` has `mindbase` and `airis-agent` disabled
- [x] Verify health check polling appears in output
- [x] Verify `~/.claude.json` has `"url": "http://localhost:9400/sse"` (not `"url": "npx"`)
- [x] Verify `curl http://localhost:9400/health` returns healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)