### PR TITLE
security: remove shell=True and $SHELL dependency from _run_command

### DIFF
--- a/src/superclaude/cli/install_mcp.py
+++ b/src/superclaude/cli/install_mcp.py
@@ -94,7 +94,10 @@ MCP_SERVERS = {
 
 def _run_command(cmd: List[str], **kwargs) -> subprocess.CompletedProcess:
     """
-    Run a command with proper cross-platform shell handling.
+    Run a command with proper cross-platform handling.
+
+    Uses shell=False (list-based execution) on all platforms to prevent
+    command injection via environment variables like $SHELL.
 
     Args:
         cmd: Command as list of strings
@@ -112,16 +115,8 @@ def _run_command(cmd: List[str], **kwargs) -> subprocess.CompletedProcess:
     if platform.system() == "Windows":
         # On Windows, wrap command in 'cmd /c' to properly handle commands like npx
         cmd = ["cmd", "/c"] + cmd
-        return subprocess.run(cmd, **kwargs)
-    else:
-        # macOS/Linux: Use string format with proper shell to support aliases
-        cmd_str = " ".join(shlex.quote(str(arg)) for arg in cmd)
 
-        # Use the user's shell to execute the command, supporting aliases
-        user_shell = os.environ.get("SHELL", "/bin/bash")
-        return subprocess.run(
-            cmd_str, shell=True, env=os.environ, executable=user_shell, **kwargs
-        )
+    return subprocess.run(cmd, **kwargs)
 
 
 def check_docker_available() -> bool:


### PR DESCRIPTION
## Summary

Removes `shell=True` and the user-controlled `$SHELL` environment variable from `_run_command()` in `install_mcp.py`, eliminating an arbitrary code execution vector.

**Fixes #536**

## Problem

The `_run_command()` function on non-Windows platforms:
1. Reads `$SHELL` from the environment and uses it as `executable`
2. Joins command arguments into a string and runs with `shell=True`
3. Passes the full `os.environ` to child processes

An attacker who controls `$SHELL` (via `.env`, shell profile, or parent process) can route all subprocess calls through a malicious binary. The full env passthrough also risks leaking secrets to child processes.

## Changes

- Uses `subprocess.run(cmd, shell=False)` with list-based args on all platforms
- Removes `os.environ.get("SHELL")` dependency
- Removes explicit `env=os.environ` passthrough (subprocess inherits env by default)
- Windows `cmd /c` wrapping is preserved

## Test plan

- [ ] Verify MCP server installation works on macOS/Linux without `shell=True`
- [ ] Verify Windows installation still works with `cmd /c` wrapping
- [ ] Verify `claude mcp add` commands execute correctly with list-based args

🤖 Generated with [Claude Code](https://claude.com/claude-code)