### PR TITLE
security: add SHA-256 integrity check for downloaded docker-compose file

### DIFF
--- a/src/superclaude/cli/install_mcp.py
+++ b/src/superclaude/cli/install_mcp.py
@@ -5,6 +5,7 @@ Installs and manages MCP servers using the latest Claude Code API.
 Based on the installer logic from commit d4a17fc but adapted for modern Claude Code.
 """
 
+import hashlib
 import os
 import platform
 import shlex
@@ -177,8 +178,10 @@ def install_airis_gateway(dry_run: bool = False) -> bool:
     install_dir.mkdir(parents=True, exist_ok=True)
     click.echo(f"   📁 Installation directory: {install_dir}")
 
-    # Download docker-compose file
+    # Download docker-compose file with integrity verification
     click.echo("   📥 Downloading docker-compose configuration...")
+    # SHA-256 of the known-good docker-compose.dist.yml
+    EXPECTED_COMPOSE_HASH = "ed87f3f86089a0f2ee0ca1ee95af89f67b0801f399215ad6482e0426412e761a"
     try:
         result = _run_command(
             [
@@ -198,6 +201,26 @@ def install_airis_gateway(dry_run: bool = False) -> bool:
                 err=True,
             )
             return False
+
+        # Verify file integrity before executing
+        actual_hash = hashlib.sha256(compose_file.read_bytes()).hexdigest()
+        if actual_hash != EXPECTED_COMPOSE_HASH:
+            click.echo(
+                "   ❌ Docker compose file integrity check failed!", err=True
+            )
+            click.echo(
+                f"   Expected SHA-256: {EXPECTED_COMPOSE_HASH}", err=True
+            )
+            click.echo(
+                f"   Actual SHA-256:   {actual_hash}", err=True
+            )
+            click.echo(
+                "   The downloaded file may have been tampered with. "
+                "Aborting installation.", err=True
+            )
+            compose_file.unlink(missing_ok=True)
+            return False
+        click.echo("   ✅ Integrity check passed (SHA-256 verified)")
     except Exception as e:
         click.echo(f"   ❌ Error downloading: {e}", err=True)
         return False


### PR DESCRIPTION
## Summary

Adds SHA-256 hash verification for the docker-compose.dist.yml file downloaded during AIRIS MCP Gateway installation, preventing execution of tampered compose files.

**Fixes #537**

## Problem

The installer downloads `docker-compose.dist.yml` from a raw GitHub URL and immediately runs `docker compose up -d` — with no checksum, no signature, and no pinned commit. If the upstream repo is compromised, arbitrary containers execute on the user's machine with host filesystem access (via `${PWD}` read-write mounts).

## Changes

- Added `hashlib` import
- After download, computes SHA-256 of the compose file and compares against a known-good hash
- If the hash doesn't match: prints expected vs actual hash, deletes the file, aborts installation
- Hash constant (`EXPECTED_COMPOSE_HASH`) must be updated when the upstream compose file is intentionally changed

## Test plan

- [ ] Verify clean installation succeeds with matching hash
- [ ] Verify installation aborts cleanly when hash doesn't match (e.g., modify the expected hash constant)
- [ ] Verify the downloaded file is deleted on hash mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)