### PR TITLE
feat(confidence): implement skill checks in TS + enrich Python, add CLI/install test coverage

### DIFF
--- a/.claude/skills/confidence-check/SKILL.md
+++ b/.claude/skills/confidence-check/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: Confidence Check
 description: Pre-implementation confidence assessment (≥90% required). Use before starting any implementation to verify readiness with duplicate check, architecture compliance, official docs verification, OSS references, and root cause identification.
-allowed-tools: Read, Grep, Glob, WebFetch, WebSearch
 ---
 
 # Confidence Check Skill
@@ -112,11 +111,20 @@ If Total < 0.70:   ❌ STOP - Request more context
 
 ## Implementation Details
 
-The TypeScript implementation is available in `confidence.ts` for reference, containing:
+A working TypeScript implementation lives in `confidence.ts`, mirroring the Python
+`ConfidenceChecker` (`src/superclaude/pm_agent/confidence.py`):
 
-- `confidenceCheck(context)` - Main assessment function
-- Detailed check implementations
-- Context interface definitions
+- `ConfidenceChecker.assess(context)` - Main assessment function (returns 0.0–1.0)
+- All five checks are implemented, not just flag look-ups:
+  - **Duplicates**: scans the project (`*.py`/`*.ts`/`*.js`) for matching file names or
+    `def`/`class`/`function` definitions; matches are recorded in `context.potential_duplicates`
+  - **Architecture**: reads the tech stack from `CLAUDE.md` and package files, then flags
+    anti-patterns (e.g. custom API in a Supabase project) into `context.architecture_warnings`
+  - **OSS / docs / root cause**: inspect provided references and reject hedged
+    ("maybe", "probably", "assume", …) root-cause statements
+- Each check still honors an explicit `*_complete` / `*_verified` context flag override for
+  testing and pre-checked scenarios.
+- `Context` interface definitions for all inputs and outputs.
 
 ## ROI
 

--- a/.claude/skills/confidence-check/confidence.ts
+++ b/.claude/skills/confidence-check/confidence.ts
@@ -4,168 +4,628 @@
  * Prevents wrong-direction execution by assessing confidence BEFORE starting.
  * Requires ≥90% confidence to proceed with implementation.
  *
+ * Token Budget: 100-200 tokens
+ * ROI: 25-250x token savings when stopping wrong direction
+ *
  * Test Results (2025-10-21):
  * - Precision: 1.000 (no false positives)
  * - Recall: 1.000 (no false negatives)
  * - 8/8 test cases passed
+ *
+ * Confidence Levels:
+ *    - High (≥90%): Root cause identified, solution verified, no duplication, architecture-compliant
+ *    - Medium (70-89%): Multiple approaches possible, trade-offs require consideration
+ *    - Low (<70%): Investigation incomplete, unclear root cause, missing official docs
  */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { join, dirname, relative } from 'path';
 
 export interface Context {
   task?: string;
+  test_file?: string;
+  test_name?: string;
+  markers?: string[];
   duplicate_check_complete?: boolean;
   architecture_check_complete?: boolean;
   official_docs_verified?: boolean;
   oss_reference_complete?: boolean;
   root_cause_identified?: boolean;
   confidence_checks?: string[];
+  // Investigation inputs (used when the corresponding *_complete flag is absent)
+  project_root?: string;
+  feature_name?: string;
+  target_name?: string;
+  proposed_technology?: string;
+  proposed_solution?: string;
+  root_cause?: string;
+  oss_references?: string[];
+  documentation_urls?: string[];
+  references?: string[];
+  research_notes?: string;
+  // Investigation outputs populated by the checks
+  potential_duplicates?: string[];
+  detected_tech_stack?: Record<string, boolean>;
+  architecture_warnings?: string[];
+  oss_recommendation?: string;
+  root_cause_warning?: string;
   [key: string]: any;
 }
 
 /**
- * Assess confidence level (0.0 - 1.0)
+ * Pre-implementation confidence assessment
  *
- * Investigation Phase Checks:
- * 1. No duplicate implementations? (25%)
- * 2. Architecture compliance? (25%)
- * 3. Official documentation verified? (20%)
- * 4. Working OSS implementations referenced? (15%)
- * 5. Root cause identified? (15%)
+ * Usage:
+ *   const checker = new ConfidenceChecker();
+ *   const confidence = await checker.assess(context);
  *
- * @param context - Task context with investigation flags
- * @returns Confidence score (0.0 = no confidence, 1.0 = absolute certainty)
+ *   if (confidence >= 0.9) {
+ *     // High confidence - proceed immediately
+ *   } else if (confidence >= 0.7) {
+ *     // Medium confidence - present options to user
+ *   } else {
+ *     // Low confidence - STOP and request clarification
+ *   }
+ */
+export class ConfidenceChecker {
+  /**
+   * Assess confidence level (0.0 - 1.0)
+   *
+   * Investigation Phase Checks:
+   * 1. No duplicate implementations? (25%)
+   * 2. Architecture compliance? (25%)
+   * 3. Official documentation verified? (20%)
+   * 4. Working OSS implementations referenced? (15%)
+   * 5. Root cause identified? (15%)
+   *
+   * @param context - Task context with investigation flags
+   * @returns Confidence score (0.0 = no confidence, 1.0 = absolute certainty)
+   */
+  async assess(context: Context): Promise<number> {
+    let score = 0.0;
+    const checks: string[] = [];
+
+    // Check 1: No duplicate implementations (25%)
+    if (this.noDuplicates(context)) {
+      score += 0.25;
+      checks.push("✅ No duplicate implementations found");
+    } else {
+      checks.push("❌ Check for existing implementations first");
+    }
+
+    // Check 2: Architecture compliance (25%)
+    if (this.architectureCompliant(context)) {
+      score += 0.25;
+      checks.push("✅ Uses existing tech stack (e.g., Supabase)");
+    } else {
+      checks.push("❌ Verify architecture compliance (avoid reinventing)");
+    }
+
+    // Check 3: Official documentation verified (20%)
+    if (this.hasOfficialDocs(context)) {
+      score += 0.2;
+      checks.push("✅ Official documentation verified");
+    } else {
+      checks.push("❌ Read official docs first");
+    }
+
+    // Check 4: Working OSS implementations referenced (15%)
+    if (this.hasOssReference(context)) {
+      score += 0.15;
+      checks.push("✅ Working OSS implementation found");
+    } else {
+      checks.push("❌ Search for OSS implementations");
+    }
+
+    // Check 5: Root cause identified (15%)
+    if (this.rootCauseIdentified(context)) {
+      score += 0.15;
+      checks.push("✅ Root cause identified");
+    } else {
+      checks.push("❌ Continue investigation to identify root cause");
+    }
+
+    // Store check results for reporting
+    context.confidence_checks = checks;
+
+    // Display checks
+    console.log("📋 Confidence Checks:");
+    checks.forEach(check => console.log(`   ${check}`));
+    console.log("");
+
+    return score;
+  }
+
+  /**
+   * Check if official documentation exists
+   *
+   * Looks for:
+   * - README.md in project
+   * - CLAUDE.md with relevant patterns
+   * - docs/ directory with related content
+   */
+  private hasOfficialDocs(context: Context): boolean {
+    // Check context flag first (for testing)
+    if ('official_docs_verified' in context) {
+      return context.official_docs_verified ?? false;
+    }
+
+    // Check for test file path
+    const testFile = context.test_file;
+    if (!testFile) {
+      return false;
+    }
+
+    // Walk up directory tree to find project root (same logic as Python version)
+    let projectRoot = dirname(testFile);
+
+    while (true) {
+      // Check for documentation files
+      if (existsSync(join(projectRoot, 'README.md'))) {
+        return true;
+      }
+      if (existsSync(join(projectRoot, 'CLAUDE.md'))) {
+        return true;
+      }
+      if (existsSync(join(projectRoot, 'docs'))) {
+        return true;
+      }
+
+      // Move up one directory
+      const parent = dirname(projectRoot);
+      if (parent === projectRoot) break; // Reached root (same as Python: parent != project_root)
+      projectRoot = parent;
+    }
+
+    return false;
+  }
+
+  /**
+   * Check for duplicate implementations
+   *
+   * Before implementing, verify:
+   * - No existing similar functions/modules (Glob/Grep)
+   * - No helper functions that solve the same problem
+   * - No libraries that provide this functionality
+   *
+   * Returns true if no duplicates found (investigation complete)
+   */
+  private noDuplicates(context: Context): boolean {
+    // Allow explicit override via context flag (testing / pre-checked scenarios)
+    if ('duplicate_check_complete' in context) {
+      return context.duplicate_check_complete ?? false;
+    }
+
+    const featureName =
+      context.feature_name || context.target_name || context.test_name || '';
+    if (!featureName) {
+      return false;
+    }
+
+    const projectRoot = this.findProjectRoot(context);
+    if (!projectRoot) {
+      return false; // Can't verify without project root
+    }
+
+    const similar = this.searchCodebase(projectRoot, featureName, [
+      'node_modules', '.venv', 'venv', '__pycache__', '.git',
+    ]);
+
+    if (similar.length > 0) {
+      context.potential_duplicates = similar.slice(0, 5);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Check architecture compliance
+   *
+   * Verify solution uses existing tech stack:
+   * - Supabase project → Use Supabase APIs (not custom API)
+   * - Next.js project → Use Next.js patterns (not custom routing)
+   * - Turborepo → Use workspace patterns (not manual scripts)
+   *
+   * Returns true if solution aligns with project architecture
+   */
+  private architectureCompliant(context: Context): boolean {
+    // Allow explicit override via context flag
+    if ('architecture_check_complete' in context) {
+      return context.architecture_check_complete ?? false;
+    }
+
+    const projectRoot = this.findProjectRoot(context);
+    if (!projectRoot) {
+      return false;
+    }
+
+    const techStack = this.readTechStack(projectRoot);
+    if (Object.keys(techStack).length === 0) {
+      return false;
+    }
+
+    context.detected_tech_stack = techStack;
+
+    const proposedTech = context.proposed_technology ?? '';
+    if (!proposedTech) {
+      // Tech stack is known and nothing risky proposed -> compliant
+      return true;
+    }
+
+    const antiPatterns = this.checkArchitectureAntiPatterns(techStack, proposedTech);
+    if (antiPatterns.length > 0) {
+      context.architecture_warnings = antiPatterns;
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Check if working OSS implementations referenced
+   *
+   * Search for:
+   * - Similar open-source solutions
+   * - Reference implementations in popular projects
+   * - Community best practices
+   *
+   * Returns true if OSS reference found and analyzed
+   */
+  private hasOssReference(context: Context): boolean {
+    // Allow explicit override via context flag
+    if ('oss_reference_complete' in context) {
+      return context.oss_reference_complete ?? false;
+    }
+
+    // Explicit references gathered during investigation
+    if (context.oss_references?.length) return true;
+    if (context.documentation_urls?.length) return true;
+    if (context.references?.length) return true;
+
+    const notes = context.research_notes ?? '';
+    if (notes.length > 50) return true;
+
+    // Check if docs/research directory has relevant analysis
+    const projectRoot = this.findProjectRoot(context);
+    if (projectRoot) {
+      const researchDir = join(projectRoot, 'docs', 'research');
+      if (existsSync(researchDir)) {
+        try {
+          if (readdirSync(researchDir).some(f => f.endsWith('.md'))) {
+            return true;
+          }
+        } catch {
+          // ignore unreadable dir
+        }
+      }
+    }
+
+    context.oss_recommendation =
+      'Search for OSS implementations using WebSearch or Context7 MCP';
+    return false;
+  }
+
+  /**
+   * Check if root cause is identified with high certainty
+   *
+   * Verify:
+   * - Problem source pinpointed (not guessing)
+   * - Solution addresses root cause (not symptoms)
+   * - Fix verified against official docs/OSS patterns
+   *
+   * Returns true if root cause clearly identified
+   */
+  private rootCauseIdentified(context: Context): boolean {
+    // Allow explicit override via context flag
+    if ('root_cause_identified' in context) {
+      return context.root_cause_identified ?? false;
+    }
+
+    const rootCause = context.root_cause ?? '';
+    if (!rootCause) {
+      context.root_cause_warning = 'Root cause not documented in context';
+      return false;
+    }
+
+    // Validate root cause is specific (not hedged with uncertainty language)
+    const uncertaintyPatterns = [
+      /\bprobably\b/, /\bmaybe\b/, /\bmight\b/, /\bcould be\b/, /\bpossibly\b/,
+      /\bnot sure\b/, /\bguess\b/, /\bthink\b/, /\bassume\b/, /\bunclear\b/, /\bunknown\b/,
+    ];
+    const lower = rootCause.toLowerCase();
+    for (const pattern of uncertaintyPatterns) {
+      if (pattern.test(lower)) {
+        context.root_cause_warning = `Root cause contains uncertainty language: '${pattern.source}'`;
+        return false;
+      }
+    }
+
+    // A credible root cause comes with a concrete proposed solution
+    const solution = context.proposed_solution ?? '';
+    if (!solution) {
+      context.root_cause_warning = 'No proposed solution documented';
+      return false;
+    }
+    if (solution.length < 20) {
+      context.root_cause_warning = 'Proposed solution too brief';
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Find the project root directory from context.
+   *
+   * Uses an explicit `project_root`, otherwise walks up from `test_file` looking
+   * for pyproject.toml / CLAUDE.md / .git / package.json.
+   */
+  private findProjectRoot(context: Context): string | null {
+    if (context.project_root) {
+      return context.project_root;
+    }
+
+    const testFile = context.test_file;
+    if (!testFile) {
+      return null;
+    }
+
+    let current: string;
+    try {
+      current = statSync(testFile).isFile() ? dirname(testFile) : testFile;
+    } catch {
+      current = dirname(testFile);
+    }
+
+    const markers = ['pyproject.toml', 'CLAUDE.md', '.git', 'package.json'];
+    while (true) {
+      if (markers.some(m => existsSync(join(current, m)))) {
+        return current;
+      }
+      const parent = dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+    return null;
+  }
+
+  /**
+   * Recursively collect files under `root` (skipping `excludeDirs`), capped to keep
+   * the walk cheap on large trees.
+   */
+  private walkFiles(root: string, excludeDirs: string[], limit = 2000): string[] {
+    const out: string[] = [];
+    const stack = [root];
+    while (stack.length > 0 && out.length < limit) {
+      const dir = stack.pop()!;
+      let entries: string[];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        const full = join(dir, entry);
+        if (excludeDirs.includes(entry)) continue;
+        let isDir = false;
+        try {
+          isDir = statSync(full).isDirectory();
+        } catch {
+          continue;
+        }
+        if (isDir) {
+          stack.push(full);
+        } else {
+          out.push(full);
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Search the codebase for files related to `searchTerm`.
+   *
+   * A file matches when its name resembles the search term, or when it defines a
+   * def/class/function with that exact name. Returns project-relative paths (max 10).
+   */
+  private searchCodebase(root: string, searchTerm: string, excludeDirs: string[]): string[] {
+    const results: string[] = [];
+    const searchLower = searchTerm.toLowerCase().replace(/[_-]/g, '');
+    const exts = ['.py', '.ts', '.js'];
+
+    for (const file of this.walkFiles(root, excludeDirs)) {
+      if (!exts.some(e => file.endsWith(e))) continue;
+
+      const base = file.split('/').pop() ?? file;
+      const stem = base.replace(/\.[^.]+$/, '').toLowerCase().replace(/[_-]/g, '');
+      if (stem.includes(searchLower) || searchLower.includes(stem)) {
+        results.push(relative(root, file));
+        if (results.length >= 10) break;
+        continue;
+      }
+
+      try {
+        const content = readFileSync(file, 'utf-8');
+        if (content.length < 100000) {
+          const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          if (new RegExp(`\\b(def|class|function)\\s+${escaped}\\b`, 'i').test(content)) {
+            results.push(relative(root, file));
+            if (results.length >= 10) break;
+          }
+        }
+      } catch {
+        // ignore unreadable file
+      }
+    }
+    return results.slice(0, 10);
+  }
+
+  /**
+   * Read tech stack from CLAUDE.md and project files.
+   */
+  private readTechStack(projectRoot: string): Record<string, boolean> {
+    const techStack: Record<string, boolean> = {};
+
+    const claudeMd = join(projectRoot, 'CLAUDE.md');
+    if (existsSync(claudeMd)) {
+      try {
+        const content = readFileSync(claudeMd, 'utf-8');
+        techStack.has_claude_md = true;
+        const techPatterns: Record<string, RegExp> = {
+          supabase: /\bsupabase\b/i,
+          nextjs: /\bnext\.?js\b/i,
+          react: /\breact\b/i,
+          python: /\bpython\b/i,
+          typescript: /\btypescript\b/i,
+          turborepo: /\bturborepo\b/i,
+          uv: /\buv\b/i,
+          pytest: /\bpytest\b/i,
+        };
+        for (const [tech, pattern] of Object.entries(techPatterns)) {
+          if (pattern.test(content)) techStack[tech] = true;
+        }
+      } catch {
+        // ignore unreadable CLAUDE.md
+      }
+    }
+
+    if (existsSync(join(projectRoot, 'pyproject.toml'))) techStack.python_project = true;
+    if (existsSync(join(projectRoot, 'package.json'))) techStack.node_project = true;
+    if (existsSync(join(projectRoot, 'turbo.json'))) techStack.turborepo = true;
+
+    return techStack;
+  }
+
+  /**
+   * Check the proposed approach against the detected tech stack.
+   */
+  private checkArchitectureAntiPatterns(
+    techStack: Record<string, boolean>,
+    proposedTech: string
+  ): string[] {
+    const warnings: string[] = [];
+    const proposed = proposedTech.toLowerCase();
+
+    if (techStack.supabase) {
+      if (proposed.includes('custom api') || proposed.includes('express')) {
+        warnings.push(
+          'Supabase project detected - consider using Supabase APIs instead of custom API'
+        );
+      }
+      if (proposed.includes('custom auth')) {
+        warnings.push(
+          'Supabase project detected - consider using Supabase Auth instead of custom authentication'
+        );
+      }
+    }
+
+    if (techStack.nextjs && proposed.includes('custom routing')) {
+      warnings.push(
+        'Next.js project detected - use Next.js App Router instead of custom routing'
+      );
+    }
+
+    if (techStack.uv && proposed.includes('pip install')) {
+      warnings.push("UV project detected - use 'uv pip install' instead of 'pip install'");
+    }
+
+    return warnings;
+  }
+
+  /**
+   * Check if existing patterns can be followed
+   *
+   * Looks for:
+   * - Similar test files
+   * - Common naming conventions
+   * - Established directory structure
+   */
+  private hasExistingPatterns(context: Context): boolean {
+    const testFile = context.test_file;
+    if (!testFile) {
+      return false;
+    }
+
+    const testDir = dirname(testFile);
+
+    // Check for other test files in same directory
+    if (existsSync(testDir)) {
+      try {
+        const files = readdirSync(testDir);
+        const testFiles = files.filter(f =>
+          f.startsWith('test_') && f.endsWith('.py')
+        );
+        return testFiles.length > 1;
+      } catch {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if implementation path is clear
+   *
+   * Considers:
+   * - Test name suggests clear purpose
+   * - Markers indicate test type
+   * - Context has sufficient information
+   */
+  private hasClearPath(context: Context): boolean {
+    // Check test name clarity
+    const testName = context.test_name ?? '';
+    if (!testName || testName === 'test_example') {
+      return false;
+    }
+
+    // Check for markers indicating test type
+    const markers = context.markers ?? [];
+    const knownMarkers = new Set([
+      'unit', 'integration', 'hallucination',
+      'performance', 'confidence_check', 'self_check'
+    ]);
+
+    const hasMarkers = markers.some(m => knownMarkers.has(m));
+
+    return hasMarkers || testName.length > 10;
+  }
+
+  /**
+   * Get recommended action based on confidence level
+   *
+   * @param confidence - Confidence score (0.0 - 1.0)
+   * @returns Recommended action
+   */
+  getRecommendation(confidence: number): string {
+    if (confidence >= 0.9) {
+      return "✅ High confidence (≥90%) - Proceed with implementation";
+    } else if (confidence >= 0.7) {
+      return "⚠️ Medium confidence (70-89%) - Continue investigation, DO NOT implement yet";
+    } else {
+      return "❌ Low confidence (<70%) - STOP and continue investigation loop";
+    }
+  }
+}
+
+/**
+ * Legacy function-based API for backward compatibility
+ *
+ * @deprecated Use ConfidenceChecker class instead
  */
 export async function confidenceCheck(context: Context): Promise<number> {
-  let score = 0.0;
-  const checks: string[] = [];
-
-  // Check 1: No duplicate implementations (25%)
-  if (noDuplicates(context)) {
-    score += 0.25;
-    checks.push("✅ No duplicate implementations found");
-  } else {
-    checks.push("❌ Check for existing implementations first");
-  }
-
-  // Check 2: Architecture compliance (25%)
-  if (architectureCompliant(context)) {
-    score += 0.25;
-    checks.push("✅ Uses existing tech stack (e.g., Supabase)");
-  } else {
-    checks.push("❌ Verify architecture compliance (avoid reinventing)");
-  }
-
-  // Check 3: Official documentation verified (20%)
-  if (hasOfficialDocs(context)) {
-    score += 0.2;
-    checks.push("✅ Official documentation verified");
-  } else {
-    checks.push("❌ Read official docs first");
-  }
-
-  // Check 4: Working OSS implementations referenced (15%)
-  if (hasOssReference(context)) {
-    score += 0.15;
-    checks.push("✅ Working OSS implementation found");
-  } else {
-    checks.push("❌ Search for OSS implementations");
-  }
-
-  // Check 5: Root cause identified (15%)
-  if (rootCauseIdentified(context)) {
-    score += 0.15;
-    checks.push("✅ Root cause identified");
-  } else {
-    checks.push("❌ Continue investigation to identify root cause");
-  }
-
-  // Store check results
-  context.confidence_checks = checks;
-
-  // Display checks
-  console.log("📋 Confidence Checks:");
-  checks.forEach(check => console.log(`   ${check}`));
-  console.log("");
-
-  return score;
+  const checker = new ConfidenceChecker();
+  return checker.assess(context);
 }
 
 /**
- * Check for duplicate implementations
+ * Legacy getRecommendation for backward compatibility
  *
- * Before implementing, verify:
- * - No existing similar functions/modules (Glob/Grep)
- * - No helper functions that solve the same problem
- * - No libraries that provide this functionality
- */
-function noDuplicates(context: Context): boolean {
-  return context.duplicate_check_complete ?? false;
-}
-
-/**
- * Check architecture compliance
- *
- * Verify solution uses existing tech stack:
- * - Supabase project → Use Supabase APIs (not custom API)
- * - Next.js project → Use Next.js patterns (not custom routing)
- * - Turborepo → Use workspace patterns (not manual scripts)
- */
-function architectureCompliant(context: Context): boolean {
-  return context.architecture_check_complete ?? false;
-}
-
-/**
- * Check if official documentation verified
- *
- * For testing: uses context flag 'official_docs_verified'
- * For production: checks for README.md, CLAUDE.md, docs/ directory
- */
-function hasOfficialDocs(context: Context): boolean {
-  // Check context flag (for testing and runtime)
-  if ('official_docs_verified' in context) {
-    return context.official_docs_verified ?? false;
-  }
-
-  // Fallback: check for documentation files (production)
-  // This would require filesystem access in Node.js
-  return false;
-}
-
-/**
- * Check if working OSS implementations referenced
- *
- * Search for:
- * - Similar open-source solutions
- * - Reference implementations in popular projects
- * - Community best practices
- */
-function hasOssReference(context: Context): boolean {
-  return context.oss_reference_complete ?? false;
-}
-
-/**
- * Check if root cause is identified with high certainty
- *
- * Verify:
- * - Problem source pinpointed (not guessing)
- * - Solution addresses root cause (not symptoms)
- * - Fix verified against official docs/OSS patterns
- */
-function rootCauseIdentified(context: Context): boolean {
-  return context.root_cause_identified ?? false;
-}
-
-/**
- * Get recommended action based on confidence level
- *
- * @param confidence - Confidence score (0.0 - 1.0)
- * @returns Recommended action
+ * @deprecated Use ConfidenceChecker.getRecommendation() instead
  */
 export function getRecommendation(confidence: number): string {
-  if (confidence >= 0.9) {
-    return "✅ High confidence (≥90%) - Proceed with implementation";
-  } else if (confidence >= 0.7) {
-    return "⚠️ Medium confidence (70-89%) - Continue investigation, DO NOT implement yet";
-  } else {
-    return "❌ Low confidence (<70%) - STOP and continue investigation loop";
-  }
+  const checker = new ConfidenceChecker();
+  return checker.getRecommendation(confidence);
 }

--- a/plugins/superclaude/skills/confidence-check/SKILL.md
+++ b/plugins/superclaude/skills/confidence-check/SKILL.md
@@ -111,11 +111,20 @@ If Total < 0.70:   ❌ STOP - Request more context
 
 ## Implementation Details
 
-The TypeScript implementation is available in `confidence.ts` for reference, containing:
+A working TypeScript implementation lives in `confidence.ts`, mirroring the Python
+`ConfidenceChecker` (`src/superclaude/pm_agent/confidence.py`):
 
-- `confidenceCheck(context)` - Main assessment function
-- Detailed check implementations
-- Context interface definitions
+- `ConfidenceChecker.assess(context)` - Main assessment function (returns 0.0–1.0)
+- All five checks are implemented, not just flag look-ups:
+  - **Duplicates**: scans the project (`*.py`/`*.ts`/`*.js`) for matching file names or
+    `def`/`class`/`function` definitions; matches are recorded in `context.potential_duplicates`
+  - **Architecture**: reads the tech stack from `CLAUDE.md` and package files, then flags
+    anti-patterns (e.g. custom API in a Supabase project) into `context.architecture_warnings`
+  - **OSS / docs / root cause**: inspect provided references and reject hedged
+    ("maybe", "probably", "assume", …) root-cause statements
+- Each check still honors an explicit `*_complete` / `*_verified` context flag override for
+  testing and pre-checked scenarios.
+- `Context` interface definitions for all inputs and outputs.
 
 ## ROI
 

--- a/plugins/superclaude/skills/confidence-check/confidence.ts
+++ b/plugins/superclaude/skills/confidence-check/confidence.ts
@@ -18,8 +18,8 @@
  *    - Low (<70%): Investigation incomplete, unclear root cause, missing official docs
  */
 
-import { existsSync, readdirSync } from 'fs';
-import { join, dirname } from 'path';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { join, dirname, relative } from 'path';
 
 export interface Context {
   task?: string;
@@ -32,6 +32,23 @@ export interface Context {
   oss_reference_complete?: boolean;
   root_cause_identified?: boolean;
   confidence_checks?: string[];
+  // Investigation inputs (used when the corresponding *_complete flag is absent)
+  project_root?: string;
+  feature_name?: string;
+  target_name?: string;
+  proposed_technology?: string;
+  proposed_solution?: string;
+  root_cause?: string;
+  oss_references?: string[];
+  documentation_urls?: string[];
+  references?: string[];
+  research_notes?: string;
+  // Investigation outputs populated by the checks
+  potential_duplicates?: string[];
+  detected_tech_stack?: Record<string, boolean>;
+  architecture_warnings?: string[];
+  oss_recommendation?: string;
+  root_cause_warning?: string;
   [key: string]: any;
 }
 
@@ -174,11 +191,32 @@ export class ConfidenceChecker {
    * Returns true if no duplicates found (investigation complete)
    */
   private noDuplicates(context: Context): boolean {
-    // This is a placeholder - actual implementation should:
-    // 1. Search codebase with Glob/Grep for similar patterns
-    // 2. Check project dependencies for existing solutions
-    // 3. Verify no helper modules provide this functionality
-    return context.duplicate_check_complete ?? false;
+    // Allow explicit override via context flag (testing / pre-checked scenarios)
+    if ('duplicate_check_complete' in context) {
+      return context.duplicate_check_complete ?? false;
+    }
+
+    const featureName =
+      context.feature_name || context.target_name || context.test_name || '';
+    if (!featureName) {
+      return false;
+    }
+
+    const projectRoot = this.findProjectRoot(context);
+    if (!projectRoot) {
+      return false; // Can't verify without project root
+    }
+
+    const similar = this.searchCodebase(projectRoot, featureName, [
+      'node_modules', '.venv', 'venv', '__pycache__', '.git',
+    ]);
+
+    if (similar.length > 0) {
+      context.potential_duplicates = similar.slice(0, 5);
+      return false;
+    }
+
+    return true;
   }
 
   /**
@@ -192,11 +230,36 @@ export class ConfidenceChecker {
    * Returns true if solution aligns with project architecture
    */
   private architectureCompliant(context: Context): boolean {
-    // This is a placeholder - actual implementation should:
-    // 1. Read CLAUDE.md for project tech stack
-    // 2. Verify solution uses existing infrastructure
-    // 3. Check not reinventing provided functionality
-    return context.architecture_check_complete ?? false;
+    // Allow explicit override via context flag
+    if ('architecture_check_complete' in context) {
+      return context.architecture_check_complete ?? false;
+    }
+
+    const projectRoot = this.findProjectRoot(context);
+    if (!projectRoot) {
+      return false;
+    }
+
+    const techStack = this.readTechStack(projectRoot);
+    if (Object.keys(techStack).length === 0) {
+      return false;
+    }
+
+    context.detected_tech_stack = techStack;
+
+    const proposedTech = context.proposed_technology ?? '';
+    if (!proposedTech) {
+      // Tech stack is known and nothing risky proposed -> compliant
+      return true;
+    }
+
+    const antiPatterns = this.checkArchitectureAntiPatterns(techStack, proposedTech);
+    if (antiPatterns.length > 0) {
+      context.architecture_warnings = antiPatterns;
+      return false;
+    }
+
+    return true;
   }
 
   /**
@@ -210,11 +273,37 @@ export class ConfidenceChecker {
    * Returns true if OSS reference found and analyzed
    */
   private hasOssReference(context: Context): boolean {
-    // This is a placeholder - actual implementation should:
-    // 1. Search GitHub for similar implementations
-    // 2. Read popular OSS projects solving same problem
-    // 3. Verify approach matches community patterns
-    return context.oss_reference_complete ?? false;
+    // Allow explicit override via context flag
+    if ('oss_reference_complete' in context) {
+      return context.oss_reference_complete ?? false;
+    }
+
+    // Explicit references gathered during investigation
+    if (context.oss_references?.length) return true;
+    if (context.documentation_urls?.length) return true;
+    if (context.references?.length) return true;
+
+    const notes = context.research_notes ?? '';
+    if (notes.length > 50) return true;
+
+    // Check if docs/research directory has relevant analysis
+    const projectRoot = this.findProjectRoot(context);
+    if (projectRoot) {
+      const researchDir = join(projectRoot, 'docs', 'research');
+      if (existsSync(researchDir)) {
+        try {
+          if (readdirSync(researchDir).some(f => f.endsWith('.md'))) {
+            return true;
+          }
+        } catch {
+          // ignore unreadable dir
+        }
+      }
+    }
+
+    context.oss_recommendation =
+      'Search for OSS implementations using WebSearch or Context7 MCP';
+    return false;
   }
 
   /**
@@ -228,11 +317,221 @@ export class ConfidenceChecker {
    * Returns true if root cause clearly identified
    */
   private rootCauseIdentified(context: Context): boolean {
-    // This is a placeholder - actual implementation should:
-    // 1. Verify problem analysis complete
-    // 2. Check solution addresses root cause
-    // 3. Confirm fix aligns with best practices
-    return context.root_cause_identified ?? false;
+    // Allow explicit override via context flag
+    if ('root_cause_identified' in context) {
+      return context.root_cause_identified ?? false;
+    }
+
+    const rootCause = context.root_cause ?? '';
+    if (!rootCause) {
+      context.root_cause_warning = 'Root cause not documented in context';
+      return false;
+    }
+
+    // Validate root cause is specific (not hedged with uncertainty language)
+    const uncertaintyPatterns = [
+      /\bprobably\b/, /\bmaybe\b/, /\bmight\b/, /\bcould be\b/, /\bpossibly\b/,
+      /\bnot sure\b/, /\bguess\b/, /\bthink\b/, /\bassume\b/, /\bunclear\b/, /\bunknown\b/,
+    ];
+    const lower = rootCause.toLowerCase();
+    for (const pattern of uncertaintyPatterns) {
+      if (pattern.test(lower)) {
+        context.root_cause_warning = `Root cause contains uncertainty language: '${pattern.source}'`;
+        return false;
+      }
+    }
+
+    // A credible root cause comes with a concrete proposed solution
+    const solution = context.proposed_solution ?? '';
+    if (!solution) {
+      context.root_cause_warning = 'No proposed solution documented';
+      return false;
+    }
+    if (solution.length < 20) {
+      context.root_cause_warning = 'Proposed solution too brief';
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Find the project root directory from context.
+   *
+   * Uses an explicit `project_root`, otherwise walks up from `test_file` looking
+   * for pyproject.toml / CLAUDE.md / .git / package.json.
+   */
+  private findProjectRoot(context: Context): string | null {
+    if (context.project_root) {
+      return context.project_root;
+    }
+
+    const testFile = context.test_file;
+    if (!testFile) {
+      return null;
+    }
+
+    let current: string;
+    try {
+      current = statSync(testFile).isFile() ? dirname(testFile) : testFile;
+    } catch {
+      current = dirname(testFile);
+    }
+
+    const markers = ['pyproject.toml', 'CLAUDE.md', '.git', 'package.json'];
+    while (true) {
+      if (markers.some(m => existsSync(join(current, m)))) {
+        return current;
+      }
+      const parent = dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+    return null;
+  }
+
+  /**
+   * Recursively collect files under `root` (skipping `excludeDirs`), capped to keep
+   * the walk cheap on large trees.
+   */
+  private walkFiles(root: string, excludeDirs: string[], limit = 2000): string[] {
+    const out: string[] = [];
+    const stack = [root];
+    while (stack.length > 0 && out.length < limit) {
+      const dir = stack.pop()!;
+      let entries: string[];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        const full = join(dir, entry);
+        if (excludeDirs.includes(entry)) continue;
+        let isDir = false;
+        try {
+          isDir = statSync(full).isDirectory();
+        } catch {
+          continue;
+        }
+        if (isDir) {
+          stack.push(full);
+        } else {
+          out.push(full);
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Search the codebase for files related to `searchTerm`.
+   *
+   * A file matches when its name resembles the search term, or when it defines a
+   * def/class/function with that exact name. Returns project-relative paths (max 10).
+   */
+  private searchCodebase(root: string, searchTerm: string, excludeDirs: string[]): string[] {
+    const results: string[] = [];
+    const searchLower = searchTerm.toLowerCase().replace(/[_-]/g, '');
+    const exts = ['.py', '.ts', '.js'];
+
+    for (const file of this.walkFiles(root, excludeDirs)) {
+      if (!exts.some(e => file.endsWith(e))) continue;
+
+      const base = file.split('/').pop() ?? file;
+      const stem = base.replace(/\.[^.]+$/, '').toLowerCase().replace(/[_-]/g, '');
+      if (stem.includes(searchLower) || searchLower.includes(stem)) {
+        results.push(relative(root, file));
+        if (results.length >= 10) break;
+        continue;
+      }
+
+      try {
+        const content = readFileSync(file, 'utf-8');
+        if (content.length < 100000) {
+          const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          if (new RegExp(`\\b(def|class|function)\\s+${escaped}\\b`, 'i').test(content)) {
+            results.push(relative(root, file));
+            if (results.length >= 10) break;
+          }
+        }
+      } catch {
+        // ignore unreadable file
+      }
+    }
+    return results.slice(0, 10);
+  }
+
+  /**
+   * Read tech stack from CLAUDE.md and project files.
+   */
+  private readTechStack(projectRoot: string): Record<string, boolean> {
+    const techStack: Record<string, boolean> = {};
+
+    const claudeMd = join(projectRoot, 'CLAUDE.md');
+    if (existsSync(claudeMd)) {
+      try {
+        const content = readFileSync(claudeMd, 'utf-8');
+        techStack.has_claude_md = true;
+        const techPatterns: Record<string, RegExp> = {
+          supabase: /\bsupabase\b/i,
+          nextjs: /\bnext\.?js\b/i,
+          react: /\breact\b/i,
+          python: /\bpython\b/i,
+          typescript: /\btypescript\b/i,
+          turborepo: /\bturborepo\b/i,
+          uv: /\buv\b/i,
+          pytest: /\bpytest\b/i,
+        };
+        for (const [tech, pattern] of Object.entries(techPatterns)) {
+          if (pattern.test(content)) techStack[tech] = true;
+        }
+      } catch {
+        // ignore unreadable CLAUDE.md
+      }
+    }
+
+    if (existsSync(join(projectRoot, 'pyproject.toml'))) techStack.python_project = true;
+    if (existsSync(join(projectRoot, 'package.json'))) techStack.node_project = true;
+    if (existsSync(join(projectRoot, 'turbo.json'))) techStack.turborepo = true;
+
+    return techStack;
+  }
+
+  /**
+   * Check the proposed approach against the detected tech stack.
+   */
+  private checkArchitectureAntiPatterns(
+    techStack: Record<string, boolean>,
+    proposedTech: string
+  ): string[] {
+    const warnings: string[] = [];
+    const proposed = proposedTech.toLowerCase();
+
+    if (techStack.supabase) {
+      if (proposed.includes('custom api') || proposed.includes('express')) {
+        warnings.push(
+          'Supabase project detected - consider using Supabase APIs instead of custom API'
+        );
+      }
+      if (proposed.includes('custom auth')) {
+        warnings.push(
+          'Supabase project detected - consider using Supabase Auth instead of custom authentication'
+        );
+      }
+    }
+
+    if (techStack.nextjs && proposed.includes('custom routing')) {
+      warnings.push(
+        'Next.js project detected - use Next.js App Router instead of custom routing'
+      );
+    }
+
+    if (techStack.uv && proposed.includes('pip install')) {
+      warnings.push("UV project detected - use 'uv pip install' instead of 'pip install'");
+    }
+
+    return warnings;
   }
 
   /**

--- a/skills/confidence-check/SKILL.md
+++ b/skills/confidence-check/SKILL.md
@@ -111,11 +111,20 @@ If Total < 0.70:   ❌ STOP - Request more context
 
 ## Implementation Details
 
-The TypeScript implementation is available in `confidence.ts` for reference, containing:
+A working TypeScript implementation lives in `confidence.ts`, mirroring the Python
+`ConfidenceChecker` (`src/superclaude/pm_agent/confidence.py`):
 
-- `confidenceCheck(context)` - Main assessment function
-- Detailed check implementations
-- Context interface definitions
+- `ConfidenceChecker.assess(context)` - Main assessment function (returns 0.0–1.0)
+- All five checks are implemented, not just flag look-ups:
+  - **Duplicates**: scans the project (`*.py`/`*.ts`/`*.js`) for matching file names or
+    `def`/`class`/`function` definitions; matches are recorded in `context.potential_duplicates`
+  - **Architecture**: reads the tech stack from `CLAUDE.md` and package files, then flags
+    anti-patterns (e.g. custom API in a Supabase project) into `context.architecture_warnings`
+  - **OSS / docs / root cause**: inspect provided references and reject hedged
+    ("maybe", "probably", "assume", …) root-cause statements
+- Each check still honors an explicit `*_complete` / `*_verified` context flag override for
+  testing and pre-checked scenarios.
+- `Context` interface definitions for all inputs and outputs.
 
 ## ROI
 

--- a/skills/confidence-check/confidence.ts
+++ b/skills/confidence-check/confidence.ts
@@ -18,8 +18,8 @@
  *    - Low (<70%): Investigation incomplete, unclear root cause, missing official docs
  */
 
-import { existsSync, readdirSync } from 'fs';
-import { join, dirname } from 'path';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { join, dirname, relative } from 'path';
 
 export interface Context {
   task?: string;
@@ -32,6 +32,23 @@ export interface Context {
   oss_reference_complete?: boolean;
   root_cause_identified?: boolean;
   confidence_checks?: string[];
+  // Investigation inputs (used when the corresponding *_complete flag is absent)
+  project_root?: string;
+  feature_name?: string;
+  target_name?: string;
+  proposed_technology?: string;
+  proposed_solution?: string;
+  root_cause?: string;
+  oss_references?: string[];
+  documentation_urls?: string[];
+  references?: string[];
+  research_notes?: string;
+  // Investigation outputs populated by the checks
+  potential_duplicates?: string[];
+  detected_tech_stack?: Record<string, boolean>;
+  architecture_warnings?: string[];
+  oss_recommendation?: string;
+  root_cause_warning?: string;
   [key: string]: any;
 }
 
@@ -174,11 +191,32 @@ export class ConfidenceChecker {
    * Returns true if no duplicates found (investigation complete)
    */
   private noDuplicates(context: Context): boolean {
-    // This is a placeholder - actual implementation should:
-    // 1. Search codebase with Glob/Grep for similar patterns
-    // 2. Check project dependencies for existing solutions
-    // 3. Verify no helper modules provide this functionality
-    return context.duplicate_check_complete ?? false;
+    // Allow explicit override via context flag (testing / pre-checked scenarios)
+    if ('duplicate_check_complete' in context) {
+      return context.duplicate_check_complete ?? false;
+    }
+
+    const featureName =
+      context.feature_name || context.target_name || context.test_name || '';
+    if (!featureName) {
+      return false;
+    }
+
+    const projectRoot = this.findProjectRoot(context);
+    if (!projectRoot) {
+      return false; // Can't verify without project root
+    }
+
+    const similar = this.searchCodebase(projectRoot, featureName, [
+      'node_modules', '.venv', 'venv', '__pycache__', '.git',
+    ]);
+
+    if (similar.length > 0) {
+      context.potential_duplicates = similar.slice(0, 5);
+      return false;
+    }
+
+    return true;
   }
 
   /**
@@ -192,11 +230,36 @@ export class ConfidenceChecker {
    * Returns true if solution aligns with project architecture
    */
   private architectureCompliant(context: Context): boolean {
-    // This is a placeholder - actual implementation should:
-    // 1. Read CLAUDE.md for project tech stack
-    // 2. Verify solution uses existing infrastructure
-    // 3. Check not reinventing provided functionality
-    return context.architecture_check_complete ?? false;
+    // Allow explicit override via context flag
+    if ('architecture_check_complete' in context) {
+      return context.architecture_check_complete ?? false;
+    }
+
+    const projectRoot = this.findProjectRoot(context);
+    if (!projectRoot) {
+      return false;
+    }
+
+    const techStack = this.readTechStack(projectRoot);
+    if (Object.keys(techStack).length === 0) {
+      return false;
+    }
+
+    context.detected_tech_stack = techStack;
+
+    const proposedTech = context.proposed_technology ?? '';
+    if (!proposedTech) {
+      // Tech stack is known and nothing risky proposed -> compliant
+      return true;
+    }
+
+    const antiPatterns = this.checkArchitectureAntiPatterns(techStack, proposedTech);
+    if (antiPatterns.length > 0) {
+      context.architecture_warnings = antiPatterns;
+      return false;
+    }
+
+    return true;
   }
 
   /**
@@ -210,11 +273,37 @@ export class ConfidenceChecker {
    * Returns true if OSS reference found and analyzed
    */
   private hasOssReference(context: Context): boolean {
-    // This is a placeholder - actual implementation should:
-    // 1. Search GitHub for similar implementations
-    // 2. Read popular OSS projects solving same problem
-    // 3. Verify approach matches community patterns
-    return context.oss_reference_complete ?? false;
+    // Allow explicit override via context flag
+    if ('oss_reference_complete' in context) {
+      return context.oss_reference_complete ?? false;
+    }
+
+    // Explicit references gathered during investigation
+    if (context.oss_references?.length) return true;
+    if (context.documentation_urls?.length) return true;
+    if (context.references?.length) return true;
+
+    const notes = context.research_notes ?? '';
+    if (notes.length > 50) return true;
+
+    // Check if docs/research directory has relevant analysis
+    const projectRoot = this.findProjectRoot(context);
+    if (projectRoot) {
+      const researchDir = join(projectRoot, 'docs', 'research');
+      if (existsSync(researchDir)) {
+        try {
+          if (readdirSync(researchDir).some(f => f.endsWith('.md'))) {
+            return true;
+          }
+        } catch {
+          // ignore unreadable dir
+        }
+      }
+    }
+
+    context.oss_recommendation =
+      'Search for OSS implementations using WebSearch or Context7 MCP';
+    return false;
   }
 
   /**
@@ -228,11 +317,221 @@ export class ConfidenceChecker {
    * Returns true if root cause clearly identified
    */
   private rootCauseIdentified(context: Context): boolean {
-    // This is a placeholder - actual implementation should:
-    // 1. Verify problem analysis complete
-    // 2. Check solution addresses root cause
-    // 3. Confirm fix aligns with best practices
-    return context.root_cause_identified ?? false;
+    // Allow explicit override via context flag
+    if ('root_cause_identified' in context) {
+      return context.root_cause_identified ?? false;
+    }
+
+    const rootCause = context.root_cause ?? '';
+    if (!rootCause) {
+      context.root_cause_warning = 'Root cause not documented in context';
+      return false;
+    }
+
+    // Validate root cause is specific (not hedged with uncertainty language)
+    const uncertaintyPatterns = [
+      /\bprobably\b/, /\bmaybe\b/, /\bmight\b/, /\bcould be\b/, /\bpossibly\b/,
+      /\bnot sure\b/, /\bguess\b/, /\bthink\b/, /\bassume\b/, /\bunclear\b/, /\bunknown\b/,
+    ];
+    const lower = rootCause.toLowerCase();
+    for (const pattern of uncertaintyPatterns) {
+      if (pattern.test(lower)) {
+        context.root_cause_warning = `Root cause contains uncertainty language: '${pattern.source}'`;
+        return false;
+      }
+    }
+
+    // A credible root cause comes with a concrete proposed solution
+    const solution = context.proposed_solution ?? '';
+    if (!solution) {
+      context.root_cause_warning = 'No proposed solution documented';
+      return false;
+    }
+    if (solution.length < 20) {
+      context.root_cause_warning = 'Proposed solution too brief';
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Find the project root directory from context.
+   *
+   * Uses an explicit `project_root`, otherwise walks up from `test_file` looking
+   * for pyproject.toml / CLAUDE.md / .git / package.json.
+   */
+  private findProjectRoot(context: Context): string | null {
+    if (context.project_root) {
+      return context.project_root;
+    }
+
+    const testFile = context.test_file;
+    if (!testFile) {
+      return null;
+    }
+
+    let current: string;
+    try {
+      current = statSync(testFile).isFile() ? dirname(testFile) : testFile;
+    } catch {
+      current = dirname(testFile);
+    }
+
+    const markers = ['pyproject.toml', 'CLAUDE.md', '.git', 'package.json'];
+    while (true) {
+      if (markers.some(m => existsSync(join(current, m)))) {
+        return current;
+      }
+      const parent = dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+    return null;
+  }
+
+  /**
+   * Recursively collect files under `root` (skipping `excludeDirs`), capped to keep
+   * the walk cheap on large trees.
+   */
+  private walkFiles(root: string, excludeDirs: string[], limit = 2000): string[] {
+    const out: string[] = [];
+    const stack = [root];
+    while (stack.length > 0 && out.length < limit) {
+      const dir = stack.pop()!;
+      let entries: string[];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        const full = join(dir, entry);
+        if (excludeDirs.includes(entry)) continue;
+        let isDir = false;
+        try {
+          isDir = statSync(full).isDirectory();
+        } catch {
+          continue;
+        }
+        if (isDir) {
+          stack.push(full);
+        } else {
+          out.push(full);
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Search the codebase for files related to `searchTerm`.
+   *
+   * A file matches when its name resembles the search term, or when it defines a
+   * def/class/function with that exact name. Returns project-relative paths (max 10).
+   */
+  private searchCodebase(root: string, searchTerm: string, excludeDirs: string[]): string[] {
+    const results: string[] = [];
+    const searchLower = searchTerm.toLowerCase().replace(/[_-]/g, '');
+    const exts = ['.py', '.ts', '.js'];
+
+    for (const file of this.walkFiles(root, excludeDirs)) {
+      if (!exts.some(e => file.endsWith(e))) continue;
+
+      const base = file.split('/').pop() ?? file;
+      const stem = base.replace(/\.[^.]+$/, '').toLowerCase().replace(/[_-]/g, '');
+      if (stem.includes(searchLower) || searchLower.includes(stem)) {
+        results.push(relative(root, file));
+        if (results.length >= 10) break;
+        continue;
+      }
+
+      try {
+        const content = readFileSync(file, 'utf-8');
+        if (content.length < 100000) {
+          const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          if (new RegExp(`\\b(def|class|function)\\s+${escaped}\\b`, 'i').test(content)) {
+            results.push(relative(root, file));
+            if (results.length >= 10) break;
+          }
+        }
+      } catch {
+        // ignore unreadable file
+      }
+    }
+    return results.slice(0, 10);
+  }
+
+  /**
+   * Read tech stack from CLAUDE.md and project files.
+   */
+  private readTechStack(projectRoot: string): Record<string, boolean> {
+    const techStack: Record<string, boolean> = {};
+
+    const claudeMd = join(projectRoot, 'CLAUDE.md');
+    if (existsSync(claudeMd)) {
+      try {
+        const content = readFileSync(claudeMd, 'utf-8');
+        techStack.has_claude_md = true;
+        const techPatterns: Record<string, RegExp> = {
+          supabase: /\bsupabase\b/i,
+          nextjs: /\bnext\.?js\b/i,
+          react: /\breact\b/i,
+          python: /\bpython\b/i,
+          typescript: /\btypescript\b/i,
+          turborepo: /\bturborepo\b/i,
+          uv: /\buv\b/i,
+          pytest: /\bpytest\b/i,
+        };
+        for (const [tech, pattern] of Object.entries(techPatterns)) {
+          if (pattern.test(content)) techStack[tech] = true;
+        }
+      } catch {
+        // ignore unreadable CLAUDE.md
+      }
+    }
+
+    if (existsSync(join(projectRoot, 'pyproject.toml'))) techStack.python_project = true;
+    if (existsSync(join(projectRoot, 'package.json'))) techStack.node_project = true;
+    if (existsSync(join(projectRoot, 'turbo.json'))) techStack.turborepo = true;
+
+    return techStack;
+  }
+
+  /**
+   * Check the proposed approach against the detected tech stack.
+   */
+  private checkArchitectureAntiPatterns(
+    techStack: Record<string, boolean>,
+    proposedTech: string
+  ): string[] {
+    const warnings: string[] = [];
+    const proposed = proposedTech.toLowerCase();
+
+    if (techStack.supabase) {
+      if (proposed.includes('custom api') || proposed.includes('express')) {
+        warnings.push(
+          'Supabase project detected - consider using Supabase APIs instead of custom API'
+        );
+      }
+      if (proposed.includes('custom auth')) {
+        warnings.push(
+          'Supabase project detected - consider using Supabase Auth instead of custom authentication'
+        );
+      }
+    }
+
+    if (techStack.nextjs && proposed.includes('custom routing')) {
+      warnings.push(
+        'Next.js project detected - use Next.js App Router instead of custom routing'
+      );
+    }
+
+    if (techStack.uv && proposed.includes('pip install')) {
+      warnings.push("UV project detected - use 'uv pip install' instead of 'pip install'");
+    }
+
+    return warnings;
   }
 
   /**

--- a/src/superclaude/cli/install_commands.py
+++ b/src/superclaude/cli/install_commands.py
@@ -266,6 +266,4 @@ def list_available_agents() -> List[str]:
     if not agent_source.exists():
         return []
 
-    return sorted(
-        f.stem for f in agent_source.glob("*.md") if f.stem != "README"
-    )
+    return sorted(f.stem for f in agent_source.glob("*.md") if f.stem != "README")

--- a/src/superclaude/cli/install_mcp.py
+++ b/src/superclaude/cli/install_mcp.py
@@ -495,7 +495,7 @@ def check_mcp_server_installed(server_name: str) -> bool:
         # Parse output to check if server is installed
         return server_name.lower() in output.lower()
 
-    except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, FileNotFoundError):
         return False
 
 

--- a/src/superclaude/execution/__init__.py
+++ b/src/superclaude/execution/__init__.py
@@ -150,13 +150,17 @@ def intelligent_execute(
             correction_engine = SelfCorrectionEngine(repo_path)
 
             for task_id, error in failures:
-                error_msg = str(error) if error else "Operation failed with no error details"
+                error_msg = (
+                    str(error) if error else "Operation failed with no error details"
+                )
                 import traceback as tb_module
 
                 stack_trace = ""
                 if error and error.__traceback__:
                     stack_trace = "".join(
-                        tb_module.format_exception(type(error), error, error.__traceback__)
+                        tb_module.format_exception(
+                            type(error), error, error.__traceback__
+                        )
                     )
 
                 failure_info = {

--- a/src/superclaude/pm_agent/confidence.py
+++ b/src/superclaude/pm_agent/confidence.py
@@ -209,7 +209,9 @@ class ConfidenceChecker:
             # Tech stack is known and nothing risky proposed -> compliant
             return True
 
-        anti_patterns = self._check_architecture_anti_patterns(tech_stack, proposed_tech)
+        anti_patterns = self._check_architecture_anti_patterns(
+            tech_stack, proposed_tech
+        )
         if anti_patterns:
             context["architecture_warnings"] = anti_patterns
             return False

--- a/src/superclaude/pm_agent/confidence.py
+++ b/src/superclaude/pm_agent/confidence.py
@@ -17,6 +17,10 @@ Required Checks:
     3. Official documentation verified
     4. Working OSS implementations referenced
     5. Root cause identified with high certainty
+
+Each check supports an explicit context flag override (e.g. ``duplicate_check_complete``)
+for testing or pre-checked scenarios; absent the flag, the check inspects the real
+project on disk.
 """
 
 import re
@@ -140,54 +144,77 @@ class ConfidenceChecker:
         - No helper functions that solve the same problem
         - No libraries that provide this functionality
 
+        Searches the project for files (any of *.py/*.ts/*.js) whose name matches
+        the feature, or that define a function/class/const of the same name. Any
+        match is recorded in ``context["potential_duplicates"]``.
+
         Returns True if no duplicates found (investigation complete)
         """
         # Allow explicit override via context flag (for testing or pre-checked scenarios)
         if "duplicate_check_complete" in context:
-            return context["duplicate_check_complete"]
+            return context.get("duplicate_check_complete", False)
 
-        # Search for duplicates in the project
+        feature_name = (
+            context.get("feature_name")
+            or context.get("target_name")
+            or context.get("test_name", "")
+        )
+        if not feature_name:
+            return False
+
         project_root = self._find_project_root(context)
         if not project_root:
             return False  # Can't verify without project root
 
-        target_name = context.get("target_name", context.get("test_name", ""))
-        if not target_name:
+        similar_files = self._search_codebase(
+            project_root,
+            feature_name,
+            patterns=["**/*.py", "**/*.ts", "**/*.js"],
+            exclude_dirs=["node_modules", ".venv", "venv", "__pycache__", ".git"],
+        )
+
+        if similar_files:
+            context["potential_duplicates"] = similar_files[:5]
             return False
 
-        # Search for similarly named files/functions in the codebase
-        duplicates = self._search_codebase(project_root, target_name)
-        return len(duplicates) == 0
+        return True
 
     def _architecture_compliant(self, context: Dict[str, Any]) -> bool:
         """
         Check architecture compliance
 
-        Verify solution uses existing tech stack by reading CLAUDE.md
-        and checking that the proposed approach aligns with the project.
+        Reads the project tech stack from CLAUDE.md / package files and verifies the
+        proposed approach does not reinvent existing infrastructure (e.g. introducing a
+        custom API in a Supabase project). Warnings are stored in
+        ``context["architecture_warnings"]``.
 
         Returns True if solution aligns with project architecture
         """
         # Allow explicit override via context flag
         if "architecture_check_complete" in context:
-            return context["architecture_check_complete"]
+            return context.get("architecture_check_complete", False)
 
         project_root = self._find_project_root(context)
         if not project_root:
             return False
 
-        # Check for architecture documentation
-        arch_files = ["CLAUDE.md", "PLANNING.md", "ARCHITECTURE.md"]
-        for arch_file in arch_files:
-            if (project_root / arch_file).exists():
-                return True
+        tech_stack = self._read_tech_stack(project_root)
+        if not tech_stack:
+            return False
 
-        # If no architecture docs found, check for standard config files
-        config_files = [
-            "pyproject.toml", "package.json", "Cargo.toml",
-            "go.mod", "pom.xml", "build.gradle",
-        ]
-        return any((project_root / cf).exists() for cf in config_files)
+        context["detected_tech_stack"] = tech_stack
+
+        proposed_tech = context.get("proposed_technology", "")
+        if not proposed_tech:
+            # Tech stack is known and nothing risky proposed -> compliant
+            return True
+
+        anti_patterns = self._check_architecture_anti_patterns(tech_stack, proposed_tech)
+        if anti_patterns:
+            context["architecture_warnings"] = anti_patterns
+            return False
+
+        return True
 
     def _has_oss_reference(self, context: Dict[str, Any]) -> bool:
         """
@@ -200,21 +227,30 @@ class ConfidenceChecker:
         """
         # Allow explicit override via context flag
         if "oss_reference_complete" in context:
-            return context["oss_reference_complete"]
+            return context.get("oss_reference_complete", False)
 
-        # Check if context contains reference URLs or documentation links
-        references = context.get("references", [])
-        if references:
+        # Explicit references gathered during investigation
+        if context.get("oss_references"):
+            return True
+        if context.get("documentation_urls"):
+            return True
+        if context.get("references"):
+            return True
+
+        research_notes = context.get("research_notes", "")
+        if research_notes and len(research_notes) > 50:
             return True
 
         # Check if docs/research directory has relevant analysis
         project_root = self._find_project_root(context)
         if project_root and (project_root / "docs" / "research").exists():
             research_dir = project_root / "docs" / "research"
-            research_files = list(research_dir.glob("*.md"))
-            if research_files:
+            if list(research_dir.glob("*.md")):
                 return True
 
+        context["oss_recommendation"] = (
+            "Search for OSS implementations using WebSearch or Context7 MCP"
+        )
         return False
 
     def _root_cause_identified(self, context: Dict[str, Any]) -> bool:
@@ -230,69 +266,184 @@ class ConfidenceChecker:
         """
         # Allow explicit override via context flag
         if "root_cause_identified" in context:
-            return context["root_cause_identified"]
+            return context.get("root_cause_identified", False)
 
         # Check for root cause analysis in context
         root_cause = context.get("root_cause", "")
         if not root_cause:
+            context["root_cause_warning"] = "Root cause not documented in context"
             return False
 
-        # Validate root cause is specific (not vague)
-        vague_indicators = ["maybe", "probably", "might", "possibly", "unclear", "unknown"]
+        # Validate root cause is specific (not hedged with uncertainty language)
+        uncertainty_patterns = [
+            r"\bprobably\b",
+            r"\bmaybe\b",
+            r"\bmight\b",
+            r"\bcould be\b",
+            r"\bpossibly\b",
+            r"\bnot sure\b",
+            r"\bguess\b",
+            r"\bthink\b",
+            r"\bassume\b",
+            r"\bunclear\b",
+            r"\bunknown\b",
+        ]
         root_cause_lower = root_cause.lower()
-        if any(indicator in root_cause_lower for indicator in vague_indicators):
+        for pattern in uncertainty_patterns:
+            if re.search(pattern, root_cause_lower):
+                context["root_cause_warning"] = (
+                    f"Root cause contains uncertainty language: '{pattern}'"
+                )
+                return False
+
+        # A credible root cause comes with a concrete proposed solution
+        solution = context.get("proposed_solution", "")
+        if not solution:
+            context["root_cause_warning"] = "No proposed solution documented"
             return False
 
-        # Root cause should have reasonable specificity (>10 chars)
-        return len(root_cause.strip()) > 10
+        if len(solution) < 20:
+            context["root_cause_warning"] = "Proposed solution too brief"
+            return False
+
+        return True
 
     def _find_project_root(self, context: Dict[str, Any]) -> Optional[Path]:
         """Find the project root directory from context"""
         # Check explicit project_root in context
         if "project_root" in context:
-            root = Path(context["project_root"])
-            if root.exists():
-                return root
+            return Path(context["project_root"])
 
         # Traverse up from test_file to find project root
         test_file = context.get("test_file")
         if not test_file:
             return None
 
-        current = Path(test_file).parent
+        path = Path(test_file)
+        current = path.parent if path.is_file() else path
         while current.parent != current:
-            if (current / "pyproject.toml").exists() or (current / ".git").exists():
+            if (current / "pyproject.toml").exists():
+                return current
+            if (current / "CLAUDE.md").exists():
+                return current
+            if (current / ".git").exists():
+                return current
+            if (current / "package.json").exists():
                 return current
             current = current.parent
+
         return None
 
-    def _search_codebase(self, project_root: Path, target_name: str) -> List[Path]:
+    def _search_codebase(
+        self,
+        root: Path,
+        search_term: str,
+        patterns: List[str],
+        exclude_dirs: List[str],
+    ) -> List[str]:
         """
-        Search for files/functions with similar names in the codebase
+        Search the codebase for files related to ``search_term``.
 
-        Returns list of paths to potential duplicates
+        A file matches when its name resembles the search term, or when it defines a
+        ``def``/``class``/``function`` with that exact name. Returns project-relative
+        paths (capped at 10) and skips ``exclude_dirs``.
         """
-        duplicates = []
+        results = []
+        search_lower = search_term.lower().replace("_", "").replace("-", "")
 
-        # Normalize target name for search
-        # Convert test_feature_name to feature_name
-        search_name = re.sub(r"^test_", "", target_name)
-        if not search_name:
-            return []
-
-        # Search for Python files with similar names
-        src_dirs = [project_root / "src", project_root / "lib", project_root]
-        for src_dir in src_dirs:
-            if not src_dir.exists():
-                continue
-            for py_file in src_dir.rglob("*.py"):
-                # Skip test files and __pycache__
-                if "test_" in py_file.name or "__pycache__" in str(py_file):
+        for pattern in patterns:
+            for file_path in root.glob(pattern):
+                if any(excluded in str(file_path) for excluded in exclude_dirs):
                     continue
-                if search_name.lower() in py_file.stem.lower():
-                    duplicates.append(py_file)
 
-        return duplicates
+                filename = file_path.stem.lower().replace("_", "").replace("-", "")
+                if search_lower in filename or filename in search_lower:
+                    results.append(str(file_path.relative_to(root)))
+                    continue
+
+                try:
+                    content = file_path.read_text(encoding="utf-8", errors="ignore")
+                    if len(content) < 100000:
+                        if re.search(
+                            rf"\b(def|class|function)\s+{re.escape(search_term)}\b",
+                            content,
+                            re.IGNORECASE,
+                        ):
+                            results.append(str(file_path.relative_to(root)))
+                except (OSError, PermissionError):
+                    pass
+
+        return results[:10]
+
+    def _read_tech_stack(self, project_root: Path) -> Dict[str, Any]:
+        """Read tech stack from CLAUDE.md and project files."""
+        tech_stack: Dict[str, Any] = {}
+
+        claude_md = project_root / "CLAUDE.md"
+        if claude_md.exists():
+            try:
+                content = claude_md.read_text(encoding="utf-8")
+                tech_stack["has_claude_md"] = True
+
+                tech_patterns = {
+                    "supabase": r"\bsupabase\b",
+                    "nextjs": r"\bnext\.?js\b",
+                    "react": r"\breact\b",
+                    "python": r"\bpython\b",
+                    "typescript": r"\btypescript\b",
+                    "turborepo": r"\bturborepo\b",
+                    "uv": r"\buv\b",
+                    "pytest": r"\bpytest\b",
+                }
+
+                for tech, pattern in tech_patterns.items():
+                    if re.search(pattern, content, re.IGNORECASE):
+                        tech_stack[tech] = True
+            except (OSError, PermissionError):
+                pass
+
+        if (project_root / "pyproject.toml").exists():
+            tech_stack["python_project"] = True
+        if (project_root / "package.json").exists():
+            tech_stack["node_project"] = True
+        if (project_root / "turbo.json").exists():
+            tech_stack["turborepo"] = True
+
+        return tech_stack
+
+    def _check_architecture_anti_patterns(
+        self, tech_stack: Dict[str, Any], proposed_tech: str
+    ) -> List[str]:
+        """Check the proposed approach against the detected tech stack."""
+        warnings = []
+        proposed_lower = proposed_tech.lower()
+
+        if tech_stack.get("supabase"):
+            if "custom api" in proposed_lower or "express" in proposed_lower:
+                warnings.append(
+                    "Supabase project detected - consider using Supabase APIs "
+                    "instead of custom API"
+                )
+            if "custom auth" in proposed_lower:
+                warnings.append(
+                    "Supabase project detected - consider using Supabase Auth "
+                    "instead of custom authentication"
+                )
+
+        if tech_stack.get("nextjs"):
+            if "custom routing" in proposed_lower:
+                warnings.append(
+                    "Next.js project detected - use Next.js App Router "
+                    "instead of custom routing"
+                )
+
+        if tech_stack.get("uv"):
+            if "pip install" in proposed_lower:
+                warnings.append(
+                    "UV project detected - use 'uv pip install' instead of 'pip install'"
+                )
+
+        return warnings
 
     def _has_existing_patterns(self, context: Dict[str, Any]) -> bool:
         """

--- a/src/superclaude/pm_agent/reflexion.py
+++ b/src/superclaude/pm_agent/reflexion.py
@@ -180,11 +180,17 @@ class ReflexionPattern:
             # Query mindbase via its HTTP API (default port from AIRIS config)
             result = subprocess.run(
                 [
-                    "curl", "-sf", "--max-time", "3",
-                    "-X", "POST",
+                    "curl",
+                    "-sf",
+                    "--max-time",
+                    "3",
+                    "-X",
+                    "POST",
                     "http://localhost:18003/api/search",
-                    "-H", "Content-Type: application/json",
-                    "-d", json.dumps({"query": error_signature, "limit": 1}),
+                    "-H",
+                    "Content-Type: application/json",
+                    "-d",
+                    json.dumps({"query": error_signature, "limit": 1}),
                 ],
                 capture_output=True,
                 text=True,
@@ -207,7 +213,11 @@ class ReflexionPattern:
                     "similarity": match.get("score"),
                 }
 
-        except (subprocess.TimeoutExpired, subprocess.SubprocessError, json.JSONDecodeError):
+        except (
+            subprocess.TimeoutExpired,
+            subprocess.SubprocessError,
+            json.JSONDecodeError,
+        ):
             pass  # Mindbase unavailable, fall through to local search
         except FileNotFoundError:
             pass  # curl not available

--- a/src/superclaude/skills/confidence-check/SKILL.md
+++ b/src/superclaude/skills/confidence-check/SKILL.md
@@ -111,11 +111,20 @@ If Total < 0.70:   ❌ STOP - Request more context
 
 ## Implementation Details
 
-The TypeScript implementation is available in `confidence.ts` for reference, containing:
+A working TypeScript implementation lives in `confidence.ts`, mirroring the Python
+`ConfidenceChecker` (`src/superclaude/pm_agent/confidence.py`):
 
-- `confidenceCheck(context)` - Main assessment function
-- Detailed check implementations
-- Context interface definitions
+- `ConfidenceChecker.assess(context)` - Main assessment function (returns 0.0–1.0)
+- All five checks are implemented, not just flag look-ups:
+  - **Duplicates**: scans the project (`*.py`/`*.ts`/`*.js`) for matching file names or
+    `def`/`class`/`function` definitions; matches are recorded in `context.potential_duplicates`
+  - **Architecture**: reads the tech stack from `CLAUDE.md` and package files, then flags
+    anti-patterns (e.g. custom API in a Supabase project) into `context.architecture_warnings`
+  - **OSS / docs / root cause**: inspect provided references and reject hedged
+    ("maybe", "probably", "assume", …) root-cause statements
+- Each check still honors an explicit `*_complete` / `*_verified` context flag override for
+  testing and pre-checked scenarios.
+- `Context` interface definitions for all inputs and outputs.
 
 ## ROI
 

--- a/src/superclaude/skills/confidence-check/confidence.ts
+++ b/src/superclaude/skills/confidence-check/confidence.ts
@@ -1,4 +1,4 @@
-/** 
+/**
  * Confidence Check - Pre-implementation confidence assessment
  *
  * Prevents wrong-direction execution by assessing confidence BEFORE starting.
@@ -18,8 +18,8 @@
  *    - Low (<70%): Investigation incomplete, unclear root cause, missing official docs
  */
 
-import { existsSync, readdirSync } from 'fs';
-import { join, dirname } from 'path';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { join, dirname, relative } from 'path';
 
 export interface Context {
   task?: string;
@@ -32,6 +32,23 @@ export interface Context {
   oss_reference_complete?: boolean;
   root_cause_identified?: boolean;
   confidence_checks?: string[];
+  // Investigation inputs (used when the corresponding *_complete flag is absent)
+  project_root?: string;
+  feature_name?: string;
+  target_name?: string;
+  proposed_technology?: string;
+  proposed_solution?: string;
+  root_cause?: string;
+  oss_references?: string[];
+  documentation_urls?: string[];
+  references?: string[];
+  research_notes?: string;
+  // Investigation outputs populated by the checks
+  potential_duplicates?: string[];
+  detected_tech_stack?: Record<string, boolean>;
+  architecture_warnings?: string[];
+  oss_recommendation?: string;
+  root_cause_warning?: string;
   [key: string]: any;
 }
 
@@ -128,28 +145,36 @@ export class ConfidenceChecker {
    * - docs/ directory with related content
    */
   private hasOfficialDocs(context: Context): boolean {
-    if (context.official_docs_verified !== undefined) {
-      return context.official_docs_verified;
+    // Check context flag first (for testing)
+    if ('official_docs_verified' in context) {
+      return context.official_docs_verified ?? false;
     }
 
+    // Check for test file path
     const testFile = context.test_file;
     if (!testFile) {
       return false;
     }
 
-    let dir = dirname(testFile);
+    // Walk up directory tree to find project root (same logic as Python version)
+    let projectRoot = dirname(testFile);
 
-    while (dir !== dirname(dir)) {
-      if (existsSync(join(dir, 'README.md'))) {
+    while (true) {
+      // Check for documentation files
+      if (existsSync(join(projectRoot, 'README.md'))) {
         return true;
       }
-      if (existsSync(join(dir, 'CLAUDE.md'))) {
+      if (existsSync(join(projectRoot, 'CLAUDE.md'))) {
         return true;
       }
-      if (existsSync(join(dir, 'docs'))) {
+      if (existsSync(join(projectRoot, 'docs'))) {
         return true;
       }
-      dir = dirname(dir);
+
+      // Move up one directory
+      const parent = dirname(projectRoot);
+      if (parent === projectRoot) break; // Reached root (same as Python: parent != project_root)
+      projectRoot = parent;
     }
 
     return false;
@@ -166,7 +191,32 @@ export class ConfidenceChecker {
    * Returns true if no duplicates found (investigation complete)
    */
   private noDuplicates(context: Context): boolean {
-    return context.duplicate_check_complete ?? false;
+    // Allow explicit override via context flag (testing / pre-checked scenarios)
+    if ('duplicate_check_complete' in context) {
+      return context.duplicate_check_complete ?? false;
+    }
+
+    const featureName =
+      context.feature_name || context.target_name || context.test_name || '';
+    if (!featureName) {
+      return false;
+    }
+
+    const projectRoot = this.findProjectRoot(context);
+    if (!projectRoot) {
+      return false; // Can't verify without project root
+    }
+
+    const similar = this.searchCodebase(projectRoot, featureName, [
+      'node_modules', '.venv', 'venv', '__pycache__', '.git',
+    ]);
+
+    if (similar.length > 0) {
+      context.potential_duplicates = similar.slice(0, 5);
+      return false;
+    }
+
+    return true;
   }
 
   /**
@@ -180,7 +230,36 @@ export class ConfidenceChecker {
    * Returns true if solution aligns with project architecture
    */
   private architectureCompliant(context: Context): boolean {
-    return context.architecture_check_complete ?? false;
+    // Allow explicit override via context flag
+    if ('architecture_check_complete' in context) {
+      return context.architecture_check_complete ?? false;
+    }
+
+    const projectRoot = this.findProjectRoot(context);
+    if (!projectRoot) {
+      return false;
+    }
+
+    const techStack = this.readTechStack(projectRoot);
+    if (Object.keys(techStack).length === 0) {
+      return false;
+    }
+
+    context.detected_tech_stack = techStack;
+
+    const proposedTech = context.proposed_technology ?? '';
+    if (!proposedTech) {
+      // Tech stack is known and nothing risky proposed -> compliant
+      return true;
+    }
+
+    const antiPatterns = this.checkArchitectureAntiPatterns(techStack, proposedTech);
+    if (antiPatterns.length > 0) {
+      context.architecture_warnings = antiPatterns;
+      return false;
+    }
+
+    return true;
   }
 
   /**
@@ -194,7 +273,37 @@ export class ConfidenceChecker {
    * Returns true if OSS reference found and analyzed
    */
   private hasOssReference(context: Context): boolean {
-    return context.oss_reference_complete ?? false;
+    // Allow explicit override via context flag
+    if ('oss_reference_complete' in context) {
+      return context.oss_reference_complete ?? false;
+    }
+
+    // Explicit references gathered during investigation
+    if (context.oss_references?.length) return true;
+    if (context.documentation_urls?.length) return true;
+    if (context.references?.length) return true;
+
+    const notes = context.research_notes ?? '';
+    if (notes.length > 50) return true;
+
+    // Check if docs/research directory has relevant analysis
+    const projectRoot = this.findProjectRoot(context);
+    if (projectRoot) {
+      const researchDir = join(projectRoot, 'docs', 'research');
+      if (existsSync(researchDir)) {
+        try {
+          if (readdirSync(researchDir).some(f => f.endsWith('.md'))) {
+            return true;
+          }
+        } catch {
+          // ignore unreadable dir
+        }
+      }
+    }
+
+    context.oss_recommendation =
+      'Search for OSS implementations using WebSearch or Context7 MCP';
+    return false;
   }
 
   /**
@@ -208,7 +317,221 @@ export class ConfidenceChecker {
    * Returns true if root cause clearly identified
    */
   private rootCauseIdentified(context: Context): boolean {
-    return context.root_cause_identified ?? false;
+    // Allow explicit override via context flag
+    if ('root_cause_identified' in context) {
+      return context.root_cause_identified ?? false;
+    }
+
+    const rootCause = context.root_cause ?? '';
+    if (!rootCause) {
+      context.root_cause_warning = 'Root cause not documented in context';
+      return false;
+    }
+
+    // Validate root cause is specific (not hedged with uncertainty language)
+    const uncertaintyPatterns = [
+      /\bprobably\b/, /\bmaybe\b/, /\bmight\b/, /\bcould be\b/, /\bpossibly\b/,
+      /\bnot sure\b/, /\bguess\b/, /\bthink\b/, /\bassume\b/, /\bunclear\b/, /\bunknown\b/,
+    ];
+    const lower = rootCause.toLowerCase();
+    for (const pattern of uncertaintyPatterns) {
+      if (pattern.test(lower)) {
+        context.root_cause_warning = `Root cause contains uncertainty language: '${pattern.source}'`;
+        return false;
+      }
+    }
+
+    // A credible root cause comes with a concrete proposed solution
+    const solution = context.proposed_solution ?? '';
+    if (!solution) {
+      context.root_cause_warning = 'No proposed solution documented';
+      return false;
+    }
+    if (solution.length < 20) {
+      context.root_cause_warning = 'Proposed solution too brief';
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Find the project root directory from context.
+   *
+   * Uses an explicit `project_root`, otherwise walks up from `test_file` looking
+   * for pyproject.toml / CLAUDE.md / .git / package.json.
+   */
+  private findProjectRoot(context: Context): string | null {
+    if (context.project_root) {
+      return context.project_root;
+    }
+
+    const testFile = context.test_file;
+    if (!testFile) {
+      return null;
+    }
+
+    let current: string;
+    try {
+      current = statSync(testFile).isFile() ? dirname(testFile) : testFile;
+    } catch {
+      current = dirname(testFile);
+    }
+
+    const markers = ['pyproject.toml', 'CLAUDE.md', '.git', 'package.json'];
+    while (true) {
+      if (markers.some(m => existsSync(join(current, m)))) {
+        return current;
+      }
+      const parent = dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+    return null;
+  }
+
+  /**
+   * Recursively collect files under `root` (skipping `excludeDirs`), capped to keep
+   * the walk cheap on large trees.
+   */
+  private walkFiles(root: string, excludeDirs: string[], limit = 2000): string[] {
+    const out: string[] = [];
+    const stack = [root];
+    while (stack.length > 0 && out.length < limit) {
+      const dir = stack.pop()!;
+      let entries: string[];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        const full = join(dir, entry);
+        if (excludeDirs.includes(entry)) continue;
+        let isDir = false;
+        try {
+          isDir = statSync(full).isDirectory();
+        } catch {
+          continue;
+        }
+        if (isDir) {
+          stack.push(full);
+        } else {
+          out.push(full);
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Search the codebase for files related to `searchTerm`.
+   *
+   * A file matches when its name resembles the search term, or when it defines a
+   * def/class/function with that exact name. Returns project-relative paths (max 10).
+   */
+  private searchCodebase(root: string, searchTerm: string, excludeDirs: string[]): string[] {
+    const results: string[] = [];
+    const searchLower = searchTerm.toLowerCase().replace(/[_-]/g, '');
+    const exts = ['.py', '.ts', '.js'];
+
+    for (const file of this.walkFiles(root, excludeDirs)) {
+      if (!exts.some(e => file.endsWith(e))) continue;
+
+      const base = file.split('/').pop() ?? file;
+      const stem = base.replace(/\.[^.]+$/, '').toLowerCase().replace(/[_-]/g, '');
+      if (stem.includes(searchLower) || searchLower.includes(stem)) {
+        results.push(relative(root, file));
+        if (results.length >= 10) break;
+        continue;
+      }
+
+      try {
+        const content = readFileSync(file, 'utf-8');
+        if (content.length < 100000) {
+          const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          if (new RegExp(`\\b(def|class|function)\\s+${escaped}\\b`, 'i').test(content)) {
+            results.push(relative(root, file));
+            if (results.length >= 10) break;
+          }
+        }
+      } catch {
+        // ignore unreadable file
+      }
+    }
+    return results.slice(0, 10);
+  }
+
+  /**
+   * Read tech stack from CLAUDE.md and project files.
+   */
+  private readTechStack(projectRoot: string): Record<string, boolean> {
+    const techStack: Record<string, boolean> = {};
+
+    const claudeMd = join(projectRoot, 'CLAUDE.md');
+    if (existsSync(claudeMd)) {
+      try {
+        const content = readFileSync(claudeMd, 'utf-8');
+        techStack.has_claude_md = true;
+        const techPatterns: Record<string, RegExp> = {
+          supabase: /\bsupabase\b/i,
+          nextjs: /\bnext\.?js\b/i,
+          react: /\breact\b/i,
+          python: /\bpython\b/i,
+          typescript: /\btypescript\b/i,
+          turborepo: /\bturborepo\b/i,
+          uv: /\buv\b/i,
+          pytest: /\bpytest\b/i,
+        };
+        for (const [tech, pattern] of Object.entries(techPatterns)) {
+          if (pattern.test(content)) techStack[tech] = true;
+        }
+      } catch {
+        // ignore unreadable CLAUDE.md
+      }
+    }
+
+    if (existsSync(join(projectRoot, 'pyproject.toml'))) techStack.python_project = true;
+    if (existsSync(join(projectRoot, 'package.json'))) techStack.node_project = true;
+    if (existsSync(join(projectRoot, 'turbo.json'))) techStack.turborepo = true;
+
+    return techStack;
+  }
+
+  /**
+   * Check the proposed approach against the detected tech stack.
+   */
+  private checkArchitectureAntiPatterns(
+    techStack: Record<string, boolean>,
+    proposedTech: string
+  ): string[] {
+    const warnings: string[] = [];
+    const proposed = proposedTech.toLowerCase();
+
+    if (techStack.supabase) {
+      if (proposed.includes('custom api') || proposed.includes('express')) {
+        warnings.push(
+          'Supabase project detected - consider using Supabase APIs instead of custom API'
+        );
+      }
+      if (proposed.includes('custom auth')) {
+        warnings.push(
+          'Supabase project detected - consider using Supabase Auth instead of custom authentication'
+        );
+      }
+    }
+
+    if (techStack.nextjs && proposed.includes('custom routing')) {
+      warnings.push(
+        'Next.js project detected - use Next.js App Router instead of custom routing'
+      );
+    }
+
+    if (techStack.uv && proposed.includes('pip install')) {
+      warnings.push("UV project detected - use 'uv pip install' instead of 'pip install'");
+    }
+
+    return warnings;
   }
 
   /**
@@ -227,6 +550,7 @@ export class ConfidenceChecker {
 
     const testDir = dirname(testFile);
 
+    // Check for other test files in same directory
     if (existsSync(testDir)) {
       try {
         const files = readdirSync(testDir);
@@ -251,11 +575,13 @@ export class ConfidenceChecker {
    * - Context has sufficient information
    */
   private hasClearPath(context: Context): boolean {
+    // Check test name clarity
     const testName = context.test_name ?? '';
     if (!testName || testName === 'test_example') {
       return false;
     }
 
+    // Check for markers indicating test type
     const markers = context.markers ?? [];
     const knownMarkers = new Set([
       'unit', 'integration', 'hallucination',

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""E2E tests for SuperClaude CLI and plugin system."""

--- a/tests/e2e/test_cli_e2e.py
+++ b/tests/e2e/test_cli_e2e.py
@@ -78,7 +78,15 @@ class TestCLIDoctor:
         # Should mention key components
         assert any(
             keyword in output.lower()
-            for keyword in ["superclaude", "version", "check", "health", "status", "ok", "installed"]
+            for keyword in [
+                "superclaude",
+                "version",
+                "check",
+                "health",
+                "status",
+                "ok",
+                "installed",
+            ]
         )
 
 
@@ -125,7 +133,14 @@ class TestCLIMCP:
         # Should list some MCP servers
         assert any(
             server in output.lower()
-            for server in ["tavily", "context7", "sequential", "serena", "gateway", "airis"]
+            for server in [
+                "tavily",
+                "context7",
+                "sequential",
+                "serena",
+                "gateway",
+                "airis",
+            ]
         )
 
     def test_mcp_help(self):
@@ -149,9 +164,7 @@ class TestCLIHelp:
         result = run_cli("--help")
         output = result.stdout.lower()
         # Should mention main commands
-        assert any(
-            cmd in output for cmd in ["install", "doctor", "mcp"]
-        )
+        assert any(cmd in output for cmd in ["install", "doctor", "mcp"])
 
 
 class TestPytestPluginE2E:

--- a/tests/e2e/test_cli_e2e.py
+++ b/tests/e2e/test_cli_e2e.py
@@ -1,0 +1,207 @@
+"""
+E2E tests for SuperClaude CLI commands.
+
+These tests execute actual CLI commands via subprocess to verify
+the complete user experience works correctly.
+"""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Get the venv bin directory where superclaude is installed
+VENV_BIN = Path(sys.executable).parent
+SUPERCLAUDE_CMD = VENV_BIN / "superclaude"
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+
+def run_cli(*args, timeout=30, cwd=None):
+    """Run superclaude CLI command using venv binary."""
+    if SUPERCLAUDE_CMD.exists():
+        cmd = [str(SUPERCLAUDE_CMD), *args]
+    else:
+        # Fallback: use python -m superclaude
+        cmd = [sys.executable, "-m", "superclaude", *args]
+
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=cwd,
+    )
+
+
+def run_pytest(*args, timeout=60):
+    """Run pytest using venv python."""
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=PROJECT_ROOT,
+    )
+
+
+class TestCLIVersion:
+    """Test version command."""
+
+    def test_version_flag(self):
+        """Test --version shows version info."""
+        result = run_cli("--version")
+        assert result.returncode == 0
+        assert "superclaude" in result.stdout.lower() or "4." in result.stdout
+
+    def test_help_shows_version_option(self):
+        """Test help mentions version option."""
+        result = run_cli("--help")
+        assert result.returncode == 0
+        assert "--version" in result.stdout
+
+
+class TestCLIDoctor:
+    """Test doctor command for health checks."""
+
+    def test_doctor_runs(self):
+        """Test doctor command executes without error."""
+        result = run_cli("doctor", timeout=60)
+        # Doctor should run (may have warnings but shouldn't crash)
+        assert result.returncode in [0, 1]  # 0=healthy, 1=warnings
+        # Should produce some output
+        assert len(result.stdout) > 0 or len(result.stderr) > 0
+
+    def test_doctor_checks_components(self):
+        """Test doctor checks expected components."""
+        result = run_cli("doctor", timeout=60)
+        output = result.stdout + result.stderr
+        # Should mention key components
+        assert any(
+            keyword in output.lower()
+            for keyword in ["superclaude", "version", "check", "health", "status", "ok", "installed"]
+        )
+
+
+class TestCLIInstall:
+    """Test install command for slash commands."""
+
+    def test_install_list(self):
+        """Test install --list shows available commands."""
+        result = run_cli("install", "--list")
+        assert result.returncode == 0
+        output = result.stdout + result.stderr
+        # Should list some commands
+        assert any(
+            cmd in output.lower()
+            for cmd in ["pm", "research", "implement", "test", "analyze"]
+        )
+
+    def test_install_to_temp_directory(self):
+        """Test install command installs to specified directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            commands_dir = Path(tmpdir) / "commands"
+            result = run_cli("install", "--target", str(commands_dir), timeout=60)
+            assert result.returncode == 0
+            # Should have created some .md files
+            if commands_dir.exists():
+                md_files = list(commands_dir.glob("*.md"))
+                assert len(md_files) > 0, "No command files installed"
+
+    def test_install_help(self):
+        """Test install --help shows usage."""
+        result = run_cli("install", "--help")
+        assert result.returncode == 0
+        assert "install" in result.stdout.lower()
+
+
+class TestCLIMCP:
+    """Test MCP server management commands."""
+
+    def test_mcp_list(self):
+        """Test mcp --list shows available servers."""
+        result = run_cli("mcp", "--list")
+        assert result.returncode == 0
+        output = result.stdout + result.stderr
+        # Should list some MCP servers
+        assert any(
+            server in output.lower()
+            for server in ["tavily", "context7", "sequential", "serena", "gateway", "airis"]
+        )
+
+    def test_mcp_help(self):
+        """Test mcp --help shows usage."""
+        result = run_cli("mcp", "--help")
+        assert result.returncode == 0
+        assert "mcp" in result.stdout.lower()
+
+
+class TestCLIHelp:
+    """Test help command and flags."""
+
+    def test_help_flag(self):
+        """Test --help shows usage."""
+        result = run_cli("--help")
+        assert result.returncode == 0
+        assert "superclaude" in result.stdout.lower()
+
+    def test_help_shows_commands(self):
+        """Test help shows available commands."""
+        result = run_cli("--help")
+        output = result.stdout.lower()
+        # Should mention main commands
+        assert any(
+            cmd in output for cmd in ["install", "doctor", "mcp"]
+        )
+
+
+class TestPytestPluginE2E:
+    """Test pytest plugin loads correctly."""
+
+    def test_plugin_registered(self):
+        """Test superclaude plugin is registered with pytest."""
+        result = run_pytest("--co", "-q", "tests/unit/test_confidence.py")
+        # Should collect tests without error
+        assert result.returncode == 0 or "collected" in result.stdout.lower()
+
+    def test_plugin_fixtures_available(self):
+        """Test plugin fixtures are available."""
+        result = run_pytest("--fixtures", "-q")
+        output = result.stdout + result.stderr
+        # Should list our fixtures
+        assert any(
+            fixture in output
+            for fixture in ["confidence_checker", "token_budget", "pm_context"]
+        )
+
+    def test_run_single_unit_test(self):
+        """Test running a single unit test works."""
+        result = run_pytest(
+            "tests/unit/test_confidence.py::TestConfidenceChecker::test_high_confidence_scenario",
+            "-v",
+        )
+        assert result.returncode == 0
+        assert "passed" in result.stdout.lower()
+
+
+class TestConfidenceCheckerE2E:
+    """E2E tests for confidence checker functionality."""
+
+    def test_confidence_check_workflow(self):
+        """Test complete confidence check workflow."""
+        result = run_pytest(
+            "tests/unit/test_confidence.py::TestCodebaseSearchImplementation",
+            "-v",
+            timeout=120,
+        )
+        assert result.returncode == 0
+        assert "passed" in result.stdout.lower()
+
+    def test_architecture_compliance_workflow(self):
+        """Test architecture compliance checking."""
+        result = run_pytest(
+            "tests/unit/test_confidence.py::TestTechStackDetection",
+            "-v",
+            timeout=120,
+        )
+        assert result.returncode == 0
+        assert "passed" in result.stdout.lower()

--- a/tests/integration/test_execution_engine.py
+++ b/tests/integration/test_execution_engine.py
@@ -5,8 +5,6 @@ Tests intelligent_execute, quick_execute, and safe_execute functions
 that combine reflection, parallel execution, and self-correction.
 """
 
-import pytest
-
 from superclaude.execution import intelligent_execute, quick_execute, safe_execute
 
 
@@ -15,11 +13,13 @@ class TestQuickExecute:
 
     def test_quick_execute_simple_ops(self):
         """Quick execute should run simple operations and return results"""
-        results = quick_execute([
-            lambda: "result_a",
-            lambda: "result_b",
-            lambda: 42,
-        ])
+        results = quick_execute(
+            [
+                lambda: "result_a",
+                lambda: "result_b",
+                lambda: 42,
+            ]
+        )
 
         assert results == ["result_a", "result_b", 42]
 

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -1,0 +1,191 @@
+"""
+Tests for SuperClaude CLI Main
+
+Tests command-line interface functionality.
+"""
+
+import tempfile
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from superclaude.cli.main import main
+
+
+class TestCLIGroup:
+    """Tests for main CLI group"""
+
+    def test_main_help(self):
+        """Test main help command"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "SuperClaude" in result.output
+
+    def test_main_version(self):
+        """Test version option"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--version"])
+
+        assert result.exit_code == 0
+        assert "SuperClaude" in result.output
+
+
+class TestVersionCommand:
+    """Tests for version command"""
+
+    def test_version_command(self):
+        """Test version subcommand"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["version"])
+
+        assert result.exit_code == 0
+        assert "version" in result.output.lower()
+
+
+class TestInstallCommand:
+    """Tests for install command"""
+
+    def test_install_help(self):
+        """Test install help"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["install", "--help"])
+
+        assert result.exit_code == 0
+        assert "install" in result.output.lower()
+
+    def test_install_list_flag(self):
+        """Test install --list flag"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["install", "--list"])
+
+        assert result.exit_code == 0
+        assert "Available" in result.output or "command" in result.output.lower()
+
+    @patch("superclaude.cli.install_commands.install_commands")
+    def test_install_to_custom_target(self, mock_install):
+        """Test install to custom target"""
+        mock_install.return_value = (True, "Success")
+
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = runner.invoke(main, ["install", "--target", tmpdir])
+
+        # May succeed or fail depending on mock setup
+        assert result.exit_code in [0, 1]
+
+
+class TestUpdateCommand:
+    """Tests for update command"""
+
+    def test_update_help(self):
+        """Test update help"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["update", "--help"])
+
+        assert result.exit_code == 0
+
+    def test_update_executes(self):
+        """Test update executes"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["update"])
+
+        # Update may succeed or fail depending on environment
+        assert result.exit_code in [0, 1]
+
+
+class TestMCPCommand:
+    """Tests for mcp command"""
+
+    def test_mcp_help(self):
+        """Test mcp help"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["mcp", "--help"])
+
+        assert result.exit_code == 0
+        assert "mcp" in result.output.lower() or "server" in result.output.lower()
+
+    def test_mcp_list(self):
+        """Test mcp --list"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["mcp", "--list"])
+
+        assert result.exit_code == 0
+        assert "Available" in result.output or "Server" in result.output
+
+
+class TestDoctorCommand:
+    """Tests for doctor command"""
+
+    def test_doctor_help(self):
+        """Test doctor help"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--help"])
+
+        assert result.exit_code == 0
+
+    def test_doctor_executes(self):
+        """Test doctor command executes"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor"])
+
+        # Doctor returns 0 if all checks pass, 1 otherwise
+        assert result.exit_code in [0, 1]
+        assert "doctor" in result.output.lower() or "healthy" in result.output.lower()
+
+    def test_doctor_verbose(self):
+        """Test doctor with verbose flag"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--verbose"])
+
+        assert result.exit_code in [0, 1]
+
+
+class TestInstallSkillCommand:
+    """Tests for install-skill command"""
+
+    def test_install_skill_help(self):
+        """Test install-skill help"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["install-skill", "--help"])
+
+        assert result.exit_code == 0
+
+    def test_install_skill_not_found(self):
+        """Test install-skill with unknown skill"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["install-skill", "unknown-skill-xyz-123"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_install_skill_with_force(self):
+        """Test install-skill with force flag"""
+        runner = CliRunner()
+        # Force flag should work even if skill not found
+        result = runner.invoke(main, ["install-skill", "unknown-xyz", "--force"])
+
+        # Should fail because skill not found
+        assert result.exit_code == 1
+
+
+class TestCLIEdgeCases:
+    """Edge case tests for CLI"""
+
+    def test_unknown_command(self):
+        """Test unknown command shows error"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["unknown-command"])
+
+        assert result.exit_code != 0
+
+    def test_empty_invocation_shows_usage(self):
+        """Test empty invocation shows usage info"""
+        runner = CliRunner()
+        result = runner.invoke(main, [])
+
+        # Click shows usage and exits with code 2 when no command given
+        # This is expected behavior for command groups
+        assert result.exit_code in [0, 2]
+        assert "Usage" in result.output or "superclaude" in result.output.lower()

--- a/tests/unit/test_confidence.py
+++ b/tests/unit/test_confidence.py
@@ -179,3 +179,327 @@ def test_confidence_check_marker_integration(confidence_checker):
 
     confidence = confidence_checker.assess(context)
     assert confidence >= 0.7, "Confidence should be high enough to not skip"
+
+
+class TestCodebaseSearchImplementation:
+    """Test actual codebase search logic (not just flag-based)"""
+
+    def test_find_project_root_from_test_file(self, tmp_path):
+        """Test finding project root from test file path"""
+        # Create project structure
+        (tmp_path / "pyproject.toml").touch()
+        (tmp_path / "src").mkdir()
+        test_file = tmp_path / "tests" / "test_example.py"
+        test_file.parent.mkdir()
+        test_file.touch()
+
+        checker = ConfidenceChecker()
+        context = {"test_file": str(test_file)}
+        root = checker._find_project_root(context)
+
+        assert root == tmp_path
+
+    def test_find_project_root_from_claude_md(self, tmp_path):
+        """Test finding project root via CLAUDE.md"""
+        (tmp_path / "CLAUDE.md").touch()
+        test_file = tmp_path / "deep" / "nested" / "test.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.touch()
+
+        checker = ConfidenceChecker()
+        context = {"test_file": str(test_file)}
+        root = checker._find_project_root(context)
+
+        assert root == tmp_path
+
+    def test_find_project_root_explicit(self, tmp_path):
+        """Test explicit project_root in context"""
+        checker = ConfidenceChecker()
+        context = {"project_root": str(tmp_path)}
+        root = checker._find_project_root(context)
+
+        assert root == tmp_path
+
+    def test_search_codebase_finds_similar_files(self, tmp_path):
+        """Test searching for similar file names"""
+        (tmp_path / "auth_handler.py").write_text("class AuthHandler: pass")
+        (tmp_path / "authentication.py").write_text("def authenticate(): pass")
+
+        checker = ConfidenceChecker()
+        results = checker._search_codebase(
+            tmp_path,
+            "auth",
+            patterns=["**/*.py"],
+            exclude_dirs=[],
+        )
+
+        assert len(results) >= 1
+        assert any("auth" in r.lower() for r in results)
+
+    def test_search_codebase_finds_function_definitions(self, tmp_path):
+        """Test finding function definitions in files"""
+        (tmp_path / "utils.py").write_text(
+            "def validate_token(token):\n    return True"
+        )
+
+        checker = ConfidenceChecker()
+        results = checker._search_codebase(
+            tmp_path,
+            "validate_token",
+            patterns=["**/*.py"],
+            exclude_dirs=[],
+        )
+
+        assert "utils.py" in results
+
+    def test_search_codebase_excludes_directories(self, tmp_path):
+        """Test excluding node_modules and similar directories"""
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "node_modules" / "auth.py").write_text("class Auth: pass")
+        (tmp_path / "src" / "auth.py").parent.mkdir()
+        (tmp_path / "src" / "auth.py").write_text("class Auth: pass")
+
+        checker = ConfidenceChecker()
+        results = checker._search_codebase(
+            tmp_path,
+            "auth",
+            patterns=["**/*.py"],
+            exclude_dirs=["node_modules"],
+        )
+
+        assert not any("node_modules" in r for r in results)
+        assert any("src" in r for r in results)
+
+    def test_no_duplicates_actual_search(self, tmp_path):
+        """Test duplicate detection via actual codebase search"""
+        # Create project structure with potential duplicate
+        (tmp_path / "pyproject.toml").touch()
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "auth_manager.py").write_text(
+            "class AuthManager:\n    pass"
+        )
+
+        checker = ConfidenceChecker()
+        context = {
+            "project_root": str(tmp_path),
+            "feature_name": "auth_manager",
+        }
+
+        result = checker._no_duplicates(context)
+
+        # Should find potential duplicate
+        assert result is False
+        assert "potential_duplicates" in context
+        assert len(context["potential_duplicates"]) > 0
+
+    def test_no_duplicates_no_feature_name(self):
+        """Test duplicate check returns False without feature name"""
+        checker = ConfidenceChecker()
+        context = {"project_root": "/tmp"}
+
+        result = checker._no_duplicates(context)
+
+        assert result is False
+
+
+class TestTechStackDetection:
+    """Test tech stack detection from CLAUDE.md"""
+
+    def test_read_tech_stack_from_claude_md(self, tmp_path):
+        """Test reading tech stack from CLAUDE.md"""
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("""# Project
+
+This project uses Supabase for backend.
+Built with Next.js and TypeScript.
+Uses UV for Python package management.
+""")
+
+        checker = ConfidenceChecker()
+        tech_stack = checker._read_tech_stack(tmp_path)
+
+        assert tech_stack.get("has_claude_md") is True
+        assert tech_stack.get("supabase") is True
+        assert tech_stack.get("nextjs") is True
+        assert tech_stack.get("typescript") is True
+        assert tech_stack.get("uv") is True
+
+    def test_read_tech_stack_detects_package_files(self, tmp_path):
+        """Test detecting tech stack from package files"""
+        (tmp_path / "pyproject.toml").touch()
+        (tmp_path / "package.json").touch()
+        (tmp_path / "turbo.json").touch()
+
+        checker = ConfidenceChecker()
+        tech_stack = checker._read_tech_stack(tmp_path)
+
+        assert tech_stack.get("python_project") is True
+        assert tech_stack.get("node_project") is True
+        assert tech_stack.get("turborepo") is True
+
+    def test_check_architecture_anti_patterns_supabase(self):
+        """Test detecting Supabase anti-patterns"""
+        checker = ConfidenceChecker()
+        tech_stack = {"supabase": True}
+
+        warnings = checker._check_architecture_anti_patterns(
+            tech_stack, "custom api with express"
+        )
+
+        assert len(warnings) > 0
+        assert any("Supabase" in w for w in warnings)
+
+    def test_check_architecture_anti_patterns_nextjs(self):
+        """Test detecting Next.js anti-patterns"""
+        checker = ConfidenceChecker()
+        tech_stack = {"nextjs": True}
+
+        warnings = checker._check_architecture_anti_patterns(
+            tech_stack, "custom routing solution"
+        )
+
+        assert len(warnings) > 0
+        assert any("Next.js" in w for w in warnings)
+
+    def test_check_architecture_anti_patterns_uv(self):
+        """Test detecting UV anti-patterns"""
+        checker = ConfidenceChecker()
+        tech_stack = {"uv": True}
+
+        warnings = checker._check_architecture_anti_patterns(
+            tech_stack, "pip install requests"
+        )
+
+        assert len(warnings) > 0
+        assert any("UV" in w or "uv" in w for w in warnings)
+
+    def test_architecture_compliant_actual_check(self, tmp_path):
+        """Test architecture compliance with actual tech stack check"""
+        (tmp_path / "CLAUDE.md").write_text("Uses Supabase for backend")
+        (tmp_path / "pyproject.toml").touch()
+
+        checker = ConfidenceChecker()
+        context = {
+            "project_root": str(tmp_path),
+            "proposed_technology": "custom api with express",
+        }
+
+        result = checker._architecture_compliant(context)
+
+        assert result is False
+        assert "architecture_warnings" in context
+
+
+class TestRootCauseAnalysis:
+    """Test root cause identification logic"""
+
+    def test_root_cause_with_uncertainty_language(self):
+        """Test detecting uncertainty language in root cause"""
+        checker = ConfidenceChecker()
+        uncertain_phrases = [
+            "The issue is probably in the auth module",
+            "Maybe the database connection is timing out",
+            "It might be a race condition",
+            "Could be an issue with the cache",
+            "Possibly related to memory leak",
+            "Not sure but I think it's in the parser",
+            "I guess the config is wrong",
+            "I assume the API changed",
+        ]
+
+        for phrase in uncertain_phrases:
+            context = {
+                "root_cause": phrase,
+                "proposed_solution": "A sufficiently detailed solution here",
+            }
+            result = checker._root_cause_identified(context)
+            assert result is False, f"Should reject uncertainty: {phrase}"
+            assert "root_cause_warning" in context
+
+    def test_root_cause_confident_language(self):
+        """Test accepting confident root cause statements"""
+        checker = ConfidenceChecker()
+        context = {
+            "root_cause": "The authentication fails because the token expiration check uses UTC time but the token contains local time. Line 45 in auth.py.",
+            "proposed_solution": "Convert token timestamp to UTC before comparison in validate_token function.",
+        }
+
+        result = checker._root_cause_identified(context)
+
+        assert result is True
+
+    def test_root_cause_missing_solution(self):
+        """Test rejecting when no solution provided"""
+        checker = ConfidenceChecker()
+        context = {
+            "root_cause": "The database query is inefficient",
+        }
+
+        result = checker._root_cause_identified(context)
+
+        assert result is False
+        assert "No proposed solution" in context.get("root_cause_warning", "")
+
+    def test_root_cause_brief_solution(self):
+        """Test rejecting too brief solutions"""
+        checker = ConfidenceChecker()
+        context = {
+            "root_cause": "Token validation fails",
+            "proposed_solution": "Fix token",
+        }
+
+        result = checker._root_cause_identified(context)
+
+        assert result is False
+        assert "too brief" in context.get("root_cause_warning", "")
+
+
+class TestOSSReferenceCheck:
+    """Test OSS reference validation logic"""
+
+    def test_has_oss_reference_with_urls(self):
+        """Test detecting OSS references via URLs"""
+        checker = ConfidenceChecker()
+        context = {
+            "oss_references": [
+                "https://github.com/example/project",
+            ],
+        }
+
+        result = checker._has_oss_reference(context)
+
+        assert result is True
+
+    def test_has_oss_reference_with_doc_urls(self):
+        """Test detecting documentation URLs"""
+        checker = ConfidenceChecker()
+        context = {
+            "documentation_urls": [
+                "https://docs.example.com/api",
+            ],
+        }
+
+        result = checker._has_oss_reference(context)
+
+        assert result is True
+
+    def test_has_oss_reference_with_research_notes(self):
+        """Test detecting research notes"""
+        checker = ConfidenceChecker()
+        context = {
+            "research_notes": "Investigated the official documentation. The recommended approach is to use async/await pattern as shown in the examples."
+        }
+
+        result = checker._has_oss_reference(context)
+
+        assert result is True
+
+    def test_has_oss_reference_empty(self):
+        """Test missing OSS references"""
+        checker = ConfidenceChecker()
+        context = {}
+
+        result = checker._has_oss_reference(context)
+
+        assert result is False
+        assert "oss_recommendation" in context

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -1,0 +1,124 @@
+"""
+Tests for SuperClaude Doctor Command
+
+Tests health check functionality.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestDoctor:
+    """Tests for doctor module"""
+
+    def test_run_doctor_returns_dict(self):
+        """Test run_doctor returns expected dict structure"""
+        from superclaude.cli.doctor import run_doctor
+
+        result = run_doctor()
+
+        assert isinstance(result, dict)
+        assert "checks" in result
+        assert "passed" in result
+        assert isinstance(result["checks"], list)
+
+    def test_run_doctor_with_verbose(self):
+        """Test run_doctor with verbose flag"""
+        from superclaude.cli.doctor import run_doctor
+
+        result = run_doctor(verbose=True)
+
+        assert isinstance(result, dict)
+        assert "checks" in result
+
+    def test_check_pytest_plugin_structure(self):
+        """Test pytest plugin check returns proper structure"""
+        from superclaude.cli.doctor import _check_pytest_plugin
+
+        result = _check_pytest_plugin()
+
+        assert isinstance(result, dict)
+        assert "name" in result
+        assert "passed" in result
+        assert isinstance(result["passed"], bool)
+
+    def test_check_skills_installed_structure(self):
+        """Test skills check returns proper structure"""
+        from superclaude.cli.doctor import _check_skills_installed
+
+        result = _check_skills_installed()
+
+        assert isinstance(result, dict)
+        assert "name" in result
+        assert "passed" in result
+        assert "details" in result
+
+    def test_check_skills_installed_no_skills_dir(self):
+        """Test skills check when no skills directory exists"""
+        from superclaude.cli.doctor import _check_skills_installed
+
+        with patch.object(Path, "exists", return_value=False):
+            result = _check_skills_installed()
+
+        # Should pass even without skills (optional)
+        assert result["passed"] is True
+
+    def test_check_configuration_structure(self):
+        """Test configuration check returns proper structure"""
+        from superclaude.cli.doctor import _check_configuration
+
+        result = _check_configuration()
+
+        assert isinstance(result, dict)
+        assert "name" in result
+        assert "passed" in result
+
+    def test_check_configuration_success(self):
+        """Test configuration check passes with installed package"""
+        from superclaude.cli.doctor import _check_configuration
+
+        result = _check_configuration()
+
+        # Should pass since superclaude is installed
+        assert result["passed"] is True
+        assert "details" in result
+        assert any("SuperClaude" in d for d in result["details"])
+
+    def test_all_checks_have_required_keys(self):
+        """Test all checks return required keys"""
+        from superclaude.cli.doctor import run_doctor
+
+        result = run_doctor()
+
+        for check in result["checks"]:
+            assert "name" in check
+            assert "passed" in check
+
+
+class TestDoctorEdgeCases:
+    """Edge case tests for doctor"""
+
+    def test_run_doctor_passed_reflects_all_checks(self):
+        """Test that passed reflects all check statuses"""
+        from superclaude.cli.doctor import run_doctor
+
+        result = run_doctor()
+
+        expected_passed = all(check["passed"] for check in result["checks"])
+        assert result["passed"] == expected_passed
+
+    @patch("superclaude.cli.doctor._check_pytest_plugin")
+    def test_run_doctor_aggregates_failures(self, mock_plugin_check):
+        """Test run_doctor properly aggregates check failures"""
+        mock_plugin_check.return_value = {
+            "name": "pytest plugin",
+            "passed": False,
+            "details": ["Test failure"],
+        }
+
+        from superclaude.cli.doctor import run_doctor
+
+        result = run_doctor()
+
+        # At least one check should report the mocked failure
+        assert isinstance(result, dict)

--- a/tests/unit/test_execution_init.py
+++ b/tests/unit/test_execution_init.py
@@ -150,7 +150,12 @@ class TestIntelligentExecute:
 
             # May be blocked before reaching exception, fail, or partial_failure
             # (parallel executor catches exceptions per-task)
-            assert result["status"] in ["blocked", "failed", "partial_failure", "success"]
+            assert result["status"] in [
+                "blocked",
+                "failed",
+                "partial_failure",
+                "success",
+            ]
 
     def test_execution_without_auto_correct(self):
         """Test execution with auto_correct disabled"""
@@ -220,9 +225,7 @@ class TestSafeExecute:
             (Path(tmpdir) / "PROJECT_INDEX.md").write_text("# Index")
 
             # Patch to ensure high confidence
-            with patch.object(
-                ReflectionEngine, "reflect"
-            ) as mock_reflect:
+            with patch.object(ReflectionEngine, "reflect") as mock_reflect:
                 # Create high confidence result
                 from superclaude.execution.reflection import ReflectionResult
 
@@ -254,9 +257,7 @@ class TestSafeExecute:
     def test_safe_execute_blocked_raises(self):
         """Test safe execution raises when blocked"""
         with tempfile.TemporaryDirectory():
-            with patch.object(
-                ReflectionEngine, "reflect"
-            ) as mock_reflect:
+            with patch.object(ReflectionEngine, "reflect") as mock_reflect:
                 from superclaude.execution.reflection import ReflectionResult
 
                 clarity = ReflectionResult("Clarity", 0.3, [], ["Low clarity"])
@@ -287,7 +288,9 @@ class TestIntegration:
         """Test full intelligent execution workflow"""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Create realistic project structure
-            (Path(tmpdir) / "PROJECT_INDEX.md").write_text("# Project Index\n## Structure")
+            (Path(tmpdir) / "PROJECT_INDEX.md").write_text(
+                "# Project Index\n## Structure"
+            )
 
             context = {
                 "project_index": "loaded",

--- a/tests/unit/test_execution_init.py
+++ b/tests/unit/test_execution_init.py
@@ -1,0 +1,324 @@
+"""
+Tests for Execution Module Init
+
+Tests intelligent_execute, quick_execute, and safe_execute functions.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from superclaude.execution import (
+    ConfidenceScore,
+    ReflectionEngine,
+    intelligent_execute,
+    quick_execute,
+    safe_execute,
+    should_parallelize,
+)
+
+
+class TestExports:
+    """Tests for module exports"""
+
+    def test_all_exports_available(self):
+        """Test all __all__ exports are importable"""
+        from superclaude import execution
+
+        assert hasattr(execution, "intelligent_execute")
+        assert hasattr(execution, "ReflectionEngine")
+        assert hasattr(execution, "ParallelExecutor")
+        assert hasattr(execution, "SelfCorrectionEngine")
+        assert hasattr(execution, "ConfidenceScore")
+        assert hasattr(execution, "ExecutionPlan")
+        assert hasattr(execution, "RootCause")
+        assert hasattr(execution, "Task")
+        assert hasattr(execution, "should_parallelize")
+        assert hasattr(execution, "reflect_before_execution")
+        assert hasattr(execution, "learn_from_failure")
+
+
+class TestIntelligentExecute:
+    """Tests for intelligent_execute function"""
+
+    def test_basic_execution(self):
+        """Test basic execution with simple operations"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            operations = [
+                lambda: "result1",
+                lambda: "result2",
+            ]
+
+            result = intelligent_execute(
+                task="Create a simple test function in utils.py",
+                operations=operations,
+                repo_path=Path(tmpdir),
+            )
+
+            assert result["status"] in ["success", "partial_failure", "blocked"]
+
+    def test_execution_with_context(self):
+        """Test execution with context"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create PROJECT_INDEX.md for better confidence
+            (Path(tmpdir) / "PROJECT_INDEX.md").write_text("# Index")
+
+            context = {
+                "project_index": "loaded",
+                "current_branch": "main",
+                "git_status": "clean",
+            }
+
+            operations = [lambda: "done"]
+
+            result = intelligent_execute(
+                task="Add validation function to utils.py",
+                operations=operations,
+                context=context,
+                repo_path=Path(tmpdir),
+            )
+
+            assert "confidence" in result
+
+    def test_execution_blocked_low_confidence(self):
+        """Test execution blocked when confidence is low"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Vague task should have low clarity
+            result = intelligent_execute(
+                task="improve",  # Very vague
+                operations=[lambda: "x"],
+                repo_path=Path(tmpdir),
+            )
+
+            # May be blocked or proceed depending on other factors
+            assert result["status"] in ["blocked", "success", "partial_failure"]
+
+    def test_execution_with_failing_operation(self):
+        """Test execution with operation that returns None"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create good context
+            (Path(tmpdir) / "PROJECT_INDEX.md").write_text("# Index")
+
+            context = {
+                "project_index": "loaded",
+                "current_branch": "main",
+                "git_status": "clean",
+            }
+
+            operations = [
+                lambda: "success",
+                lambda: None,  # Failure
+            ]
+
+            result = intelligent_execute(
+                task="Create test function with validation in module.py",
+                operations=operations,
+                context=context,
+                repo_path=Path(tmpdir),
+                auto_correct=True,
+            )
+
+            # Should have at least one failure
+            if result["status"] != "blocked":
+                assert result["status"] in ["success", "partial_failure"]
+
+    def test_execution_with_exception(self):
+        """Test execution handles exceptions"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "PROJECT_INDEX.md").write_text("# Index")
+
+            context = {
+                "project_index": "loaded",
+                "current_branch": "main",
+                "git_status": "clean",
+            }
+
+            def failing_op():
+                raise ValueError("Test exception")
+
+            operations = [failing_op]
+
+            result = intelligent_execute(
+                task="Create validation function in utils.py module",
+                operations=operations,
+                context=context,
+                repo_path=Path(tmpdir),
+                auto_correct=True,
+            )
+
+            # May be blocked before reaching exception, fail, or partial_failure
+            # (parallel executor catches exceptions per-task)
+            assert result["status"] in ["blocked", "failed", "partial_failure", "success"]
+
+    def test_execution_without_auto_correct(self):
+        """Test execution with auto_correct disabled"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "PROJECT_INDEX.md").write_text("# Index")
+
+            context = {
+                "project_index": "loaded",
+                "current_branch": "main",
+                "git_status": "clean",
+            }
+
+            operations = [lambda: None]
+
+            result = intelligent_execute(
+                task="Add function to module.py file",
+                operations=operations,
+                context=context,
+                repo_path=Path(tmpdir),
+                auto_correct=False,
+            )
+
+            assert result["status"] in ["blocked", "success", "partial_failure"]
+
+
+class TestQuickExecute:
+    """Tests for quick_execute function"""
+
+    def test_quick_execute_single(self):
+        """Test quick execution with single operation"""
+        operations = [lambda: "result"]
+
+        results = quick_execute(operations)
+
+        assert len(results) == 1
+        assert results[0] == "result"
+
+    def test_quick_execute_multiple(self):
+        """Test quick execution with multiple operations"""
+        operations = [
+            lambda: "a",
+            lambda: "b",
+            lambda: "c",
+        ]
+
+        results = quick_execute(operations)
+
+        assert len(results) == 3
+        assert set(results) == {"a", "b", "c"}
+
+    def test_quick_execute_returns_list(self):
+        """Test quick execution returns a list"""
+        operations = [lambda: 42]
+        results = quick_execute(operations)
+
+        assert isinstance(results, list)
+        assert len(results) == 1
+
+
+class TestSafeExecute:
+    """Tests for safe_execute function"""
+
+    def test_safe_execute_success(self):
+        """Test safe execution with successful operation"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create good context
+            (Path(tmpdir) / "PROJECT_INDEX.md").write_text("# Index")
+
+            # Patch to ensure high confidence
+            with patch.object(
+                ReflectionEngine, "reflect"
+            ) as mock_reflect:
+                # Create high confidence result
+                from superclaude.execution.reflection import ReflectionResult
+
+                clarity = ReflectionResult("Clarity", 0.9, [], [])
+                mistakes = ReflectionResult("Mistakes", 1.0, [], [])
+                context_ready = ReflectionResult("Context", 0.8, [], [])
+
+                mock_reflect.return_value = ConfidenceScore(
+                    requirement_clarity=clarity,
+                    mistake_check=mistakes,
+                    context_ready=context_ready,
+                    confidence=0.9,
+                    should_proceed=True,
+                    blockers=[],
+                    recommendations=[],
+                )
+
+                # This may still fail due to implementation details
+                try:
+                    result = safe_execute(
+                        task="Create validation function",
+                        operation=lambda: "success",
+                    )
+                    assert result == "success"
+                except RuntimeError:
+                    # Blocked or failed is also valid outcome
+                    pass
+
+    def test_safe_execute_blocked_raises(self):
+        """Test safe execution raises when blocked"""
+        with tempfile.TemporaryDirectory():
+            with patch.object(
+                ReflectionEngine, "reflect"
+            ) as mock_reflect:
+                from superclaude.execution.reflection import ReflectionResult
+
+                clarity = ReflectionResult("Clarity", 0.3, [], ["Low clarity"])
+                mistakes = ReflectionResult("Mistakes", 0.5, [], [])
+                context_ready = ReflectionResult("Context", 0.3, [], [])
+
+                mock_reflect.return_value = ConfidenceScore(
+                    requirement_clarity=clarity,
+                    mistake_check=mistakes,
+                    context_ready=context_ready,
+                    confidence=0.3,
+                    should_proceed=False,
+                    blockers=["Low confidence"],
+                    recommendations=["Clarify task"],
+                )
+
+                with pytest.raises(RuntimeError, match="blocked"):
+                    safe_execute(
+                        task="vague task",
+                        operation=lambda: "x",
+                    )
+
+
+class TestIntegration:
+    """Integration tests for execution module"""
+
+    def test_full_workflow(self):
+        """Test full intelligent execution workflow"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create realistic project structure
+            (Path(tmpdir) / "PROJECT_INDEX.md").write_text("# Project Index\n## Structure")
+
+            context = {
+                "project_index": "loaded",
+                "current_branch": "feature/test",
+                "git_status": "clean",
+            }
+
+            executed = []
+
+            def op1():
+                executed.append("op1")
+                return "op1_result"
+
+            def op2():
+                executed.append("op2")
+                return "op2_result"
+
+            result = intelligent_execute(
+                task="Add two new functions to utils.py module file",
+                operations=[op1, op2],
+                context=context,
+                repo_path=Path(tmpdir),
+            )
+
+            # If not blocked, operations should have executed
+            if result["status"] != "blocked":
+                assert len(executed) == 2
+
+    def test_should_parallelize_helper(self):
+        """Test should_parallelize helper function"""
+        assert should_parallelize([1]) is False
+        assert should_parallelize([1, 2]) is False
+        assert should_parallelize([1, 2, 3]) is True
+        assert should_parallelize([1, 2, 3, 4, 5]) is True

--- a/tests/unit/test_install_mcp.py
+++ b/tests/unit/test_install_mcp.py
@@ -1,0 +1,319 @@
+"""
+Tests for MCP Server Installation Module
+
+Tests MCP server installation and management functionality.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+
+class TestMCPServerRegistry:
+    """Tests for MCP server registry"""
+
+    def test_mcp_servers_registry_exists(self):
+        """Test MCP_SERVERS registry is defined"""
+        from superclaude.cli.install_mcp import MCP_SERVERS
+
+        assert isinstance(MCP_SERVERS, dict)
+        assert len(MCP_SERVERS) > 0
+
+    def test_airis_gateway_defined(self):
+        """Test AIRIS gateway configuration exists"""
+        from superclaude.cli.install_mcp import AIRIS_GATEWAY
+
+        assert isinstance(AIRIS_GATEWAY, dict)
+        assert "name" in AIRIS_GATEWAY
+        assert "endpoint" in AIRIS_GATEWAY
+        assert "transport" in AIRIS_GATEWAY
+
+    def test_server_has_required_fields(self):
+        """Test each server has required fields"""
+        from superclaude.cli.install_mcp import MCP_SERVERS
+
+        required_fields = ["name", "description", "transport", "command"]
+
+        for server_key, server_info in MCP_SERVERS.items():
+            for field in required_fields:
+                assert field in server_info, f"{server_key} missing {field}"
+
+    def test_server_transport_types(self):
+        """Test servers use valid transport types"""
+        from superclaude.cli.install_mcp import MCP_SERVERS
+
+        valid_transports = ["stdio", "sse", "websocket"]
+
+        for server_key, server_info in MCP_SERVERS.items():
+            assert server_info["transport"] in valid_transports, (
+                f"{server_key} has invalid transport: {server_info['transport']}"
+            )
+
+
+class TestCheckDockerAvailable:
+    """Tests for check_docker_available function"""
+
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_docker_available(self, mock_run):
+        """Test docker available detection"""
+        from superclaude.cli.install_mcp import check_docker_available
+
+        mock_run.return_value = MagicMock(returncode=0)
+
+        result = check_docker_available()
+
+        assert result is True
+
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_docker_not_available(self, mock_run):
+        """Test docker not available detection"""
+        from superclaude.cli.install_mcp import check_docker_available
+
+        mock_run.return_value = MagicMock(returncode=1)
+
+        result = check_docker_available()
+
+        assert result is False
+
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_docker_timeout(self, mock_run):
+        """Test docker check handles timeout"""
+        from superclaude.cli.install_mcp import check_docker_available
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=10)
+
+        result = check_docker_available()
+
+        assert result is False
+
+
+class TestCheckPrerequisites:
+    """Tests for check_prerequisites function"""
+
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_prerequisites_all_pass(self, mock_run):
+        """Test all prerequisites pass"""
+        from superclaude.cli.install_mcp import check_prerequisites
+
+        # Mock successful claude and node checks
+        mock_run.return_value = MagicMock(returncode=0, stdout="v20.0.0")
+
+        success, errors = check_prerequisites()
+
+        assert success is True
+        assert len(errors) == 0
+
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_prerequisites_missing_claude(self, mock_run):
+        """Test missing Claude CLI detected"""
+        from superclaude.cli.install_mcp import check_prerequisites
+
+        def side_effect(cmd, **kwargs):
+            if "claude" in cmd:
+                raise FileNotFoundError()
+            return MagicMock(returncode=0, stdout="v20.0.0")
+
+        mock_run.side_effect = side_effect
+
+        success, errors = check_prerequisites()
+
+        assert success is False
+        assert any("Claude CLI" in e for e in errors)
+
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_prerequisites_old_node_version(self, mock_run):
+        """Test old Node.js version detected"""
+        from superclaude.cli.install_mcp import check_prerequisites
+
+        def side_effect(cmd, **kwargs):
+            if "node" in cmd:
+                return MagicMock(returncode=0, stdout="v16.0.0")
+            return MagicMock(returncode=0, stdout="")
+
+        mock_run.side_effect = side_effect
+
+        success, errors = check_prerequisites()
+
+        assert success is False
+        assert any("version 18+" in e for e in errors)
+
+
+class TestCheckMCPServerInstalled:
+    """Tests for check_mcp_server_installed function"""
+
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_server_installed(self, mock_run):
+        """Test installed server detection"""
+        from superclaude.cli.install_mcp import check_mcp_server_installed
+
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="tavily\ncontext7\nplaywright"
+        )
+
+        assert check_mcp_server_installed("tavily") is True
+
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_server_not_installed(self, mock_run):
+        """Test uninstalled server detection"""
+        from superclaude.cli.install_mcp import check_mcp_server_installed
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="tavily\ncontext7")
+
+        assert check_mcp_server_installed("unknown-server") is False
+
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_server_check_handles_error(self, mock_run):
+        """Test server check handles errors gracefully"""
+        from superclaude.cli.install_mcp import check_mcp_server_installed
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=60)
+
+        result = check_mcp_server_installed("any-server")
+
+        assert result is False
+
+
+class TestInstallMCPServer:
+    """Tests for install_mcp_server function"""
+
+    @patch("superclaude.cli.install_mcp.check_mcp_server_installed")
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_install_already_installed(self, mock_run, mock_check):
+        """Test skips installation if already installed"""
+        from superclaude.cli.install_mcp import MCP_SERVERS, install_mcp_server
+
+        mock_check.return_value = True
+
+        server_info = MCP_SERVERS["tavily"]
+        result = install_mcp_server(server_info)
+
+        assert result is True
+        # _run_command should not be called for installation
+        # (may be called by check_mcp_server_installed)
+
+    @patch("superclaude.cli.install_mcp.check_mcp_server_installed")
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_install_dry_run(self, mock_run, mock_check):
+        """Test dry run doesn't execute commands"""
+        from superclaude.cli.install_mcp import MCP_SERVERS, install_mcp_server
+
+        mock_check.return_value = False
+
+        # Use a server without API key requirement for dry run test
+        server_info = MCP_SERVERS["context7"]
+        result = install_mcp_server(server_info, dry_run=True)
+
+        assert result is True
+
+    @patch("superclaude.cli.install_mcp.check_mcp_server_installed")
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_install_success(self, mock_run, mock_check):
+        """Test successful installation"""
+        from superclaude.cli.install_mcp import MCP_SERVERS, install_mcp_server
+
+        mock_check.return_value = False
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        server_info = MCP_SERVERS["context7"]
+        result = install_mcp_server(server_info)
+
+        assert result is True
+
+    @patch("superclaude.cli.install_mcp.check_mcp_server_installed")
+    @patch("superclaude.cli.install_mcp._run_command")
+    def test_install_failure(self, mock_run, mock_check):
+        """Test installation failure handling"""
+        from superclaude.cli.install_mcp import MCP_SERVERS, install_mcp_server
+
+        mock_check.return_value = False
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="Installation failed"
+        )
+
+        server_info = MCP_SERVERS["context7"]
+        result = install_mcp_server(server_info)
+
+        assert result is False
+
+
+class TestInstallMCPServers:
+    """Tests for install_mcp_servers main function"""
+
+    @patch("superclaude.cli.install_mcp.check_prerequisites")
+    def test_install_fails_prerequisites(self, mock_prereq):
+        """Test installation fails if prerequisites not met"""
+        from superclaude.cli.install_mcp import install_mcp_servers
+
+        mock_prereq.return_value = (False, ["Missing Claude CLI"])
+
+        success, message = install_mcp_servers(selected_servers=["tavily"])
+
+        assert success is False
+        assert "Prerequisites" in message
+
+    @patch("superclaude.cli.install_mcp.check_prerequisites")
+    @patch("superclaude.cli.install_mcp.install_airis_gateway")
+    def test_install_gateway_selection(self, mock_gateway, mock_prereq):
+        """Test AIRIS gateway installation"""
+        from superclaude.cli.install_mcp import install_mcp_servers
+
+        mock_prereq.return_value = (True, [])
+        mock_gateway.return_value = True
+
+        success, message = install_mcp_servers(
+            selected_servers=["airis-mcp-gateway"], dry_run=True
+        )
+
+        assert success is True
+
+    @patch("superclaude.cli.install_mcp.check_prerequisites")
+    @patch("superclaude.cli.install_mcp.install_mcp_server")
+    def test_install_selected_servers(self, mock_install, mock_prereq):
+        """Test installation of selected servers"""
+        from superclaude.cli.install_mcp import install_mcp_servers
+
+        mock_prereq.return_value = (True, [])
+        mock_install.return_value = True
+
+        success, message = install_mcp_servers(
+            selected_servers=["tavily", "context7"], dry_run=True
+        )
+
+        assert success is True
+
+    @patch("superclaude.cli.install_mcp.check_prerequisites")
+    def test_install_invalid_servers(self, mock_prereq):
+        """Test handling of invalid server names"""
+        from superclaude.cli.install_mcp import install_mcp_servers
+
+        mock_prereq.return_value = (True, [])
+
+        success, message = install_mcp_servers(selected_servers=["invalid-server-xyz"])
+
+        assert success is False
+        assert "No valid servers" in message
+
+
+class TestAirisGatewayInstall:
+    """Tests for AIRIS gateway installation"""
+
+    @patch("superclaude.cli.install_mcp.check_docker_available")
+    def test_gateway_requires_docker(self, mock_docker):
+        """Test gateway installation requires Docker"""
+        from superclaude.cli.install_mcp import install_airis_gateway
+
+        mock_docker.return_value = False
+
+        result = install_airis_gateway()
+
+        assert result is False
+
+    @patch("superclaude.cli.install_mcp.check_docker_available")
+    def test_gateway_dry_run(self, mock_docker):
+        """Test gateway dry run"""
+        from superclaude.cli.install_mcp import install_airis_gateway
+
+        mock_docker.return_value = True
+
+        result = install_airis_gateway(dry_run=True)
+
+        assert result is True

--- a/tests/unit/test_install_skill.py
+++ b/tests/unit/test_install_skill.py
@@ -1,0 +1,211 @@
+"""
+Tests for Skill Installation Command
+
+Tests skill installation functionality.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestInstallSkill:
+    """Tests for install_skill module"""
+
+    def test_list_available_skills_returns_list(self):
+        """Test list_available_skills returns a list"""
+        from superclaude.cli.install_skill import list_available_skills
+
+        result = list_available_skills()
+
+        assert isinstance(result, list)
+
+    def test_list_available_skills_sorted(self):
+        """Test list_available_skills returns sorted list"""
+        from superclaude.cli.install_skill import list_available_skills
+
+        result = list_available_skills()
+
+        assert result == sorted(result)
+
+    def test_install_skill_nonexistent_skill(self):
+        """Test installing nonexistent skill fails"""
+        from superclaude.cli.install_skill import install_skill_command
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "skills"
+            success, message = install_skill_command("nonexistent-skill-xyz", target)
+
+            assert success is False
+            assert "not found" in message.lower()
+
+    def test_install_skill_creates_target_dir(self):
+        """Test install_skill creates target directory"""
+        from superclaude.cli.install_skill import install_skill_command
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "new" / "nested" / "skills"
+
+            # Even if skill doesn't exist, target dir creation is attempted
+            install_skill_command("nonexistent", target)
+
+            # May or may not exist depending on when creation happens
+            # Just verify no exception is raised
+
+
+class TestGetSkillSource:
+    """Tests for _get_skill_source function"""
+
+    def test_get_skill_source_returns_none_for_unknown(self):
+        """Test _get_skill_source returns None for unknown skills"""
+        from superclaude.cli.install_skill import _get_skill_source
+
+        result = _get_skill_source("unknown-skill-xyz-123")
+
+        assert result is None
+
+    def test_get_skill_source_handles_hyphen_underscore(self):
+        """Test _get_skill_source normalizes skill names"""
+        from superclaude.cli.install_skill import _get_skill_source
+
+        # Should handle both hyphen and underscore versions
+        result1 = _get_skill_source("some-skill")
+        result2 = _get_skill_source("some_skill")
+
+        # Both should return same or None
+        assert result1 == result2 or (result1 is None and result2 is None)
+
+
+class TestIsValidSkillDir:
+    """Tests for _is_valid_skill_dir function"""
+
+    def test_is_valid_skill_dir_with_skill_md(self):
+        """Test _is_valid_skill_dir recognizes SKILL.md"""
+        from superclaude.cli.install_skill import _is_valid_skill_dir
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir)
+            (skill_dir / "SKILL.md").touch()
+
+            assert _is_valid_skill_dir(skill_dir) is True
+
+    def test_is_valid_skill_dir_with_implementation_md(self):
+        """Test _is_valid_skill_dir recognizes implementation.md"""
+        from superclaude.cli.install_skill import _is_valid_skill_dir
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir)
+            (skill_dir / "implementation.md").touch()
+
+            assert _is_valid_skill_dir(skill_dir) is True
+
+    def test_is_valid_skill_dir_with_code_files(self):
+        """Test _is_valid_skill_dir recognizes code files"""
+        from superclaude.cli.install_skill import _is_valid_skill_dir
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir)
+            (skill_dir / "main.py").touch()
+
+            assert _is_valid_skill_dir(skill_dir) is True
+
+    def test_is_valid_skill_dir_empty_dir(self):
+        """Test _is_valid_skill_dir rejects empty directory"""
+        from superclaude.cli.install_skill import _is_valid_skill_dir
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir)
+
+            assert _is_valid_skill_dir(skill_dir) is False
+
+    def test_is_valid_skill_dir_nonexistent(self):
+        """Test _is_valid_skill_dir handles nonexistent path"""
+        from superclaude.cli.install_skill import _is_valid_skill_dir
+
+        result = _is_valid_skill_dir(Path("/nonexistent/path/xyz"))
+
+        assert result is False
+
+    def test_is_valid_skill_dir_none_path(self):
+        """Test _is_valid_skill_dir handles None"""
+        from superclaude.cli.install_skill import _is_valid_skill_dir
+
+        result = _is_valid_skill_dir(None)
+
+        assert result is False
+
+
+class TestInstallSkillWithMocks:
+    """Tests with mocked skill source"""
+
+    def test_install_skill_success(self):
+        """Test successful skill installation"""
+        from superclaude.cli.install_skill import install_skill_command
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create mock skill source
+            source_dir = Path(tmpdir) / "source" / "test-skill"
+            source_dir.mkdir(parents=True)
+            (source_dir / "SKILL.md").write_text("# Test Skill")
+            (source_dir / "main.py").write_text("# Main file")
+
+            target_dir = Path(tmpdir) / "target"
+
+            with patch(
+                "superclaude.cli.install_skill._get_skill_source",
+                return_value=source_dir,
+            ):
+                success, message = install_skill_command("test-skill", target_dir)
+
+            assert success is True
+            assert "successfully" in message.lower()
+            assert (target_dir / "test-skill" / "SKILL.md").exists()
+
+    def test_install_skill_already_exists(self):
+        """Test skill installation fails if already exists"""
+        from superclaude.cli.install_skill import install_skill_command
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create mock skill source
+            source_dir = Path(tmpdir) / "source" / "test-skill"
+            source_dir.mkdir(parents=True)
+            (source_dir / "SKILL.md").write_text("# Test Skill")
+
+            target_dir = Path(tmpdir) / "target"
+            (target_dir / "test-skill").mkdir(parents=True)
+
+            with patch(
+                "superclaude.cli.install_skill._get_skill_source",
+                return_value=source_dir,
+            ):
+                success, message = install_skill_command("test-skill", target_dir)
+
+            assert success is False
+            assert "already installed" in message.lower()
+
+    def test_install_skill_force_reinstall(self):
+        """Test skill force reinstall overwrites existing"""
+        from superclaude.cli.install_skill import install_skill_command
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create mock skill source
+            source_dir = Path(tmpdir) / "source" / "test-skill"
+            source_dir.mkdir(parents=True)
+            (source_dir / "SKILL.md").write_text("# New Version")
+
+            target_dir = Path(tmpdir) / "target"
+            existing = target_dir / "test-skill"
+            existing.mkdir(parents=True)
+            (existing / "SKILL.md").write_text("# Old Version")
+
+            with patch(
+                "superclaude.cli.install_skill._get_skill_source",
+                return_value=source_dir,
+            ):
+                success, message = install_skill_command(
+                    "test-skill", target_dir, force=True
+                )
+
+            assert success is True
+            content = (target_dir / "test-skill" / "SKILL.md").read_text()
+            assert "New Version" in content

--- a/tests/unit/test_parallel.py
+++ b/tests/unit/test_parallel.py
@@ -10,9 +10,7 @@ import time
 import pytest
 
 from superclaude.execution.parallel import (
-    ExecutionPlan,
     ParallelExecutor,
-    ParallelGroup,
     Task,
     TaskStatus,
     parallel_file_operations,
@@ -164,7 +162,10 @@ class TestParallelExecutor:
         tasks = [
             Task(id="t0", description="Return 42", execute=lambda: 42, depends_on=[]),
             Task(
-                id="t1", description="Return hello", execute=lambda: "hello", depends_on=[]
+                id="t1",
+                description="Return hello",
+                execute=lambda: "hello",
+                depends_on=[],
             ),
         ]
 
@@ -210,7 +211,12 @@ class TestParallelExecutor:
 
         executor = ParallelExecutor(max_workers=1)  # Force sequential within groups
         tasks = [
-            Task(id="first", description="First", execute=make_task("first"), depends_on=[]),
+            Task(
+                id="first",
+                description="First",
+                execute=make_task("first"),
+                depends_on=[],
+            ),
             Task(
                 id="second",
                 description="Second",

--- a/tests/unit/test_reflection.py
+++ b/tests/unit/test_reflection.py
@@ -81,7 +81,11 @@ class TestReflectionEngine:
         """Specific task description should get higher clarity score"""
         result = reflection_engine.reflect(
             "Create a new REST API endpoint for /users/{id} in users.py",
-            context={"project_index": True, "current_branch": "main", "git_status": "clean"},
+            context={
+                "project_index": True,
+                "current_branch": "main",
+                "git_status": "clean",
+            },
         )
 
         assert result.requirement_clarity.score > 0.5
@@ -197,8 +201,6 @@ class TestReflectionEngine:
         result_specific = reflection_engine._reflect_clarity(
             "Create user registration endpoint", None
         )
-        result_vague = reflection_engine._reflect_clarity(
-            "improve the system", None
-        )
+        result_vague = reflection_engine._reflect_clarity("improve the system", None)
 
         assert result_specific.score > result_vague.score

--- a/tests/unit/test_self_correction.py
+++ b/tests/unit/test_self_correction.py
@@ -179,7 +179,9 @@ class TestSelfCorrectionEngine:
         """Should produce a RootCause with all fields populated"""
         failure = {"error": "invalid input: expected integer", "stack_trace": ""}
 
-        root_cause = correction_engine.analyze_root_cause("validate user input", failure)
+        root_cause = correction_engine.analyze_root_cause(
+            "validate user input", failure
+        )
 
         assert isinstance(root_cause, RootCause)
         assert root_cause.category == "validation"


### PR DESCRIPTION
## Why

The `confidence-check` skill ships in two channels (the pip-installed CLI via `src/superclaude/skills/`, and the Claude Code plugin via `plugins/superclaude/skills/`), but its **TypeScript implementation was an unfinished stub**: 4 of the 5 checks (`noDuplicates`, `architectureCompliant`, `hasOssReference`, `rootCauseIdentified`) just returned a context flag with a `// This is a placeholder` comment. The Python `ConfidenceChecker` was real but simpler than it could be.

This PR completes the TS skill and enriches the Python checker, porting the genuinely-better logic from the `kazukinakai` fork — **without** dragging in the fork's dead `airis-agent` import layer.

## What

### confidence.ts (skill) — fill the 4 placeholder checks
- **noDuplicates**: walks the project (`*.py`/`*.ts`/`*.js`, excluding `node_modules`/`.venv`/…) and matches by file name or `def`/`class`/`function <name>` definition; hits recorded in `context.potential_duplicates`.
- **architectureCompliant**: reads the tech stack from `CLAUDE.md` + package files, then flags anti-patterns (e.g. a custom API / `express` in a Supabase project, `pip install` in a `uv` project) into `context.architecture_warnings`.
- **hasOssReference / rootCauseIdentified**: inspect provided references and reject hedged root-cause statements (`maybe`, `probably`, `assume`, …) via word-boundary regex; require a concrete `proposed_solution`.
- Synced byte-identical across **all four tracked skill copies** (`src/superclaude/skills/`, `plugins/superclaude/skills/`, `skills/`, `.claude/skills/`).
- Typechecks clean under `tsc --strict` (with `@types/node`).

### confidence.py — enrich the Python checker (flat single class, no airis layer)
- New `_read_tech_stack()` and `_check_architecture_anti_patterns()`.
- `_search_codebase()` upgraded to multi-language + file-content grep.
- Richer `_root_cause_identified()` (regex uncertainty detection + solution check).
- Backward compatible: every check keeps its `*_complete` / `*_verified` flag override, and the context-key set is a **superset** accepting both the existing keys (`target_name`, `root_cause`) and the fork's (`feature_name`, `proposed_technology`, `proposed_solution`).

### Tests
- New coverage that upstream lacked: `test_cli_main`, `test_doctor`, `test_execution_init`, `test_install_mcp`, `test_install_skill`, `e2e/test_cli_e2e`.
- `test_confidence` expanded to a superset (adds project-root / search / tech-stack / anti-pattern / architecture cases on top of the existing ones).

## Verification
- `uv run python -m pytest` → **252 passed, 1 skipped** (+ 1 *pre-existing* failure unrelated to this PR: `test_execution_engine.py::test_quick_execute_empty`, a `ZeroDivisionError` in `parallel.py` on empty task lists — reproduces on a clean `master`).
- `uv run ruff check` on all touched files → clean.

## Intentionally excluded (out of scope)
- The fork's `airis-agent` Python-import integration (undeclared dependency, never activates) — dropped on purpose so the checks need **zero** optional deps.
- Fork-only `init` / `check` CLI command tests (those commands don't exist upstream).
- Circular full-suite meta-tests (`TestFullTestSuite`) that shell out to the whole `pytest` run.
- Fork's parallel/reflection/self_correction test rewrites and `reflexion.py` similarity logic — separate follow-ups.

## Follow-ups suggested
- The `confidence-check` skill is duplicated across 4 tracked locations; consider collapsing to a single source.
- Fix the pre-existing `parallel.py` empty-plan `ZeroDivisionError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)