### PR TITLE
fix: guard executor speedup division against zero elapsed time; correct UV install PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -153,8 +153,8 @@ install_uv() {
     if curl -LsSf https://astral.sh/uv/install.sh | sh; then
         print_success "UV installed successfully"
 
-        # Add UV to PATH for current session
-        export PATH="$HOME/.cargo/bin:$PATH"
+        # Add UV to PATH for current session (installer default: ~/.local/bin, or $XDG_BIN_HOME)
+        export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
 
         # Verify UV is now available
         if ! command -v uv &> /dev/null; then

--- a/src/superclaude/execution/parallel.py
+++ b/src/superclaude/execution/parallel.py
@@ -191,7 +191,11 @@ class ParallelExecutor:
             print(f"   Completed in {group_time:.2f}s")
 
         total_time = time.time() - start_time
-        actual_speedup = plan.sequential_time_estimate / total_time
+        # total_time can be exactly 0.0 for empty or near-instant plans (clock
+        # resolution), so guard the division rather than crash the whole run.
+        actual_speedup = (
+            plan.sequential_time_estimate / total_time if total_time > 0 else 1.0
+        )
 
         print("\n" + "=" * 60)
         print(f"✅ All tasks completed in {total_time:.2f}s")

--- a/tests/integration/test_execution_engine.py
+++ b/tests/integration/test_execution_engine.py
@@ -28,6 +28,19 @@ class TestQuickExecute:
         results = quick_execute([])
         assert results == []
 
+    def test_execute_handles_zero_elapsed_time(self, monkeypatch):
+        """Regression: total_time can be exactly 0.0 for empty or near-instant
+        plans (clock resolution). Computing the speedup must not raise
+        ZeroDivisionError. Freeze the clock so elapsed time is deterministically
+        0.0 — this fails hard without the guard in ParallelExecutor.execute."""
+        import superclaude.execution.parallel as parallel
+
+        monkeypatch.setattr(parallel.time, "time", lambda: 1000.0)
+
+        # Both the empty and single-op paths hit the division; neither may crash.
+        assert quick_execute([]) == []
+        assert quick_execute([lambda: "ok"]) == ["ok"]
+
     def test_quick_execute_single(self):
         """Quick execute with single operation"""
         results = quick_execute([lambda: "only"])


### PR DESCRIPTION
## Summary

Two independent, verified bug fixes surfaced while running the test suite.

### 1. `ZeroDivisionError` in `ParallelExecutor.execute()` (real defect + flaky test)

`execute()` computes `actual_speedup = plan.sequential_time_estimate / total_time`, where `total_time = time.time() - start_time`. For an empty plan — or any plan that completes within the clock's resolution — `total_time` is exactly `0.0`, which raises `ZeroDivisionError` and crashes the whole run.

This presented as a **flaky** failure of `test_quick_execute_empty` (~1 in 8 full-suite runs, depending on whether the clock ticked mid-call), but it is a genuine production defect: any sufficiently fast `execute()` call can hit it.

- **Fix:** guard the division, falling back to `1.0x` when no measurable time elapsed.
- **Regression test:** `test_execute_handles_zero_elapsed_time` freezes the clock so elapsed time is deterministically `0.0`. Verified it **fails with `ZeroDivisionError` on the current code** and **passes with the guard**.

### 2. `install.sh` exports the wrong post-install PATH for UV

After installing UV, the script exported `~/.cargo/bin` — a legacy cargo-dist location. The current UV standalone installer installs to `$XDG_BIN_HOME`, or `$HOME/.local/bin` by default; `~/.cargo/bin` is only used on explicit opt-in. On a fresh machine the subsequent `command -v uv` check therefore failed and told the user to restart their terminal unnecessarily.

- **Fix:** export `${XDG_BIN_HOME:-$HOME/.local/bin}`, matching the installer's actual default. (Verified against the current `astral.sh/uv/install.sh` destination logic.)

## Testing

- Full suite: **137 passed** (was 136 + 1 new regression test).
- Flaky `ZeroDivisionError` reproduced pre-fix, then **0 failures across 25 consecutive full-suite runs** post-fix.
- `bash -n install.sh` clean.

Both fixes are small and self-contained; happy to split into two PRs if maintainers prefer.