### PR TITLE
chore(lint): fix ruff lint/format violations blocking CI on every PR

### DIFF
--- a/src/superclaude/cli/install_commands.py
+++ b/src/superclaude/cli/install_commands.py
@@ -266,6 +266,4 @@ def list_available_agents() -> List[str]:
     if not agent_source.exists():
         return []
 
-    return sorted(
-        f.stem for f in agent_source.glob("*.md") if f.stem != "README"
-    )
+    return sorted(f.stem for f in agent_source.glob("*.md") if f.stem != "README")

--- a/src/superclaude/execution/__init__.py
+++ b/src/superclaude/execution/__init__.py
@@ -150,13 +150,17 @@ def intelligent_execute(
             correction_engine = SelfCorrectionEngine(repo_path)
 
             for task_id, error in failures:
-                error_msg = str(error) if error else "Operation failed with no error details"
+                error_msg = (
+                    str(error) if error else "Operation failed with no error details"
+                )
                 import traceback as tb_module
 
                 stack_trace = ""
                 if error and error.__traceback__:
                     stack_trace = "".join(
-                        tb_module.format_exception(type(error), error, error.__traceback__)
+                        tb_module.format_exception(
+                            type(error), error, error.__traceback__
+                        )
                     )
 
                 failure_info = {

--- a/src/superclaude/pm_agent/confidence.py
+++ b/src/superclaude/pm_agent/confidence.py
@@ -184,8 +184,12 @@ class ConfidenceChecker:
 
         # If no architecture docs found, check for standard config files
         config_files = [
-            "pyproject.toml", "package.json", "Cargo.toml",
-            "go.mod", "pom.xml", "build.gradle",
+            "pyproject.toml",
+            "package.json",
+            "Cargo.toml",
+            "go.mod",
+            "pom.xml",
+            "build.gradle",
         ]
         return any((project_root / cf).exists() for cf in config_files)
 
@@ -238,7 +242,14 @@ class ConfidenceChecker:
             return False
 
         # Validate root cause is specific (not vague)
-        vague_indicators = ["maybe", "probably", "might", "possibly", "unclear", "unknown"]
+        vague_indicators = [
+            "maybe",
+            "probably",
+            "might",
+            "possibly",
+            "unclear",
+            "unknown",
+        ]
         root_cause_lower = root_cause.lower()
         if any(indicator in root_cause_lower for indicator in vague_indicators):
             return False

--- a/src/superclaude/pm_agent/reflexion.py
+++ b/src/superclaude/pm_agent/reflexion.py
@@ -180,11 +180,17 @@ class ReflexionPattern:
             # Query mindbase via its HTTP API (default port from AIRIS config)
             result = subprocess.run(
                 [
-                    "curl", "-sf", "--max-time", "3",
-                    "-X", "POST",
+                    "curl",
+                    "-sf",
+                    "--max-time",
+                    "3",
+                    "-X",
+                    "POST",
                     "http://localhost:18003/api/search",
-                    "-H", "Content-Type: application/json",
-                    "-d", json.dumps({"query": error_signature, "limit": 1}),
+                    "-H",
+                    "Content-Type: application/json",
+                    "-d",
+                    json.dumps({"query": error_signature, "limit": 1}),
                 ],
                 capture_output=True,
                 text=True,
@@ -207,7 +213,11 @@ class ReflexionPattern:
                     "similarity": match.get("score"),
                 }
 
-        except (subprocess.TimeoutExpired, subprocess.SubprocessError, json.JSONDecodeError):
+        except (
+            subprocess.TimeoutExpired,
+            subprocess.SubprocessError,
+            json.JSONDecodeError,
+        ):
             pass  # Mindbase unavailable, fall through to local search
         except FileNotFoundError:
             pass  # curl not available

--- a/tests/integration/test_execution_engine.py
+++ b/tests/integration/test_execution_engine.py
@@ -5,8 +5,6 @@ Tests intelligent_execute, quick_execute, and safe_execute functions
 that combine reflection, parallel execution, and self-correction.
 """
 
-import pytest
-
 from superclaude.execution import intelligent_execute, quick_execute, safe_execute
 
 
@@ -15,11 +13,13 @@ class TestQuickExecute:
 
     def test_quick_execute_simple_ops(self):
         """Quick execute should run simple operations and return results"""
-        results = quick_execute([
-            lambda: "result_a",
-            lambda: "result_b",
-            lambda: 42,
-        ])
+        results = quick_execute(
+            [
+                lambda: "result_a",
+                lambda: "result_b",
+                lambda: 42,
+            ]
+        )
 
         assert results == ["result_a", "result_b", 42]
 

--- a/tests/unit/test_parallel.py
+++ b/tests/unit/test_parallel.py
@@ -10,9 +10,7 @@ import time
 import pytest
 
 from superclaude.execution.parallel import (
-    ExecutionPlan,
     ParallelExecutor,
-    ParallelGroup,
     Task,
     TaskStatus,
     parallel_file_operations,
@@ -164,7 +162,10 @@ class TestParallelExecutor:
         tasks = [
             Task(id="t0", description="Return 42", execute=lambda: 42, depends_on=[]),
             Task(
-                id="t1", description="Return hello", execute=lambda: "hello", depends_on=[]
+                id="t1",
+                description="Return hello",
+                execute=lambda: "hello",
+                depends_on=[],
             ),
         ]
 
@@ -210,7 +211,12 @@ class TestParallelExecutor:
 
         executor = ParallelExecutor(max_workers=1)  # Force sequential within groups
         tasks = [
-            Task(id="first", description="First", execute=make_task("first"), depends_on=[]),
+            Task(
+                id="first",
+                description="First",
+                execute=make_task("first"),
+                depends_on=[],
+            ),
             Task(
                 id="second",
                 description="Second",

--- a/tests/unit/test_reflection.py
+++ b/tests/unit/test_reflection.py
@@ -81,7 +81,11 @@ class TestReflectionEngine:
         """Specific task description should get higher clarity score"""
         result = reflection_engine.reflect(
             "Create a new REST API endpoint for /users/{id} in users.py",
-            context={"project_index": True, "current_branch": "main", "git_status": "clean"},
+            context={
+                "project_index": True,
+                "current_branch": "main",
+                "git_status": "clean",
+            },
         )
 
         assert result.requirement_clarity.score > 0.5
@@ -197,8 +201,6 @@ class TestReflectionEngine:
         result_specific = reflection_engine._reflect_clarity(
             "Create user registration endpoint", None
         )
-        result_vague = reflection_engine._reflect_clarity(
-            "improve the system", None
-        )
+        result_vague = reflection_engine._reflect_clarity("improve the system", None)
 
         assert result_specific.score > result_vague.score

--- a/tests/unit/test_self_correction.py
+++ b/tests/unit/test_self_correction.py
@@ -179,7 +179,9 @@ class TestSelfCorrectionEngine:
         """Should produce a RootCause with all fields populated"""
         failure = {"error": "invalid input: expected integer", "stack_trace": ""}
 
-        root_cause = correction_engine.analyze_root_cause("validate user input", failure)
+        root_cause = correction_engine.analyze_root_cause(
+            "validate user input", failure
+        )
 
         assert isinstance(root_cause, RootCause)
         assert root_cause.category == "validation"


### PR DESCRIPTION
## Summary

`ruff check src/ tests/` and `ruff format --check src/ tests/` currently fail on `master`, so the **Lint and Format Check**, **Quick Check**, and **Test Summary** CI jobs go red on every PR regardless of its content (see e.g. #569). This PR is the mechanical cleanup that makes those gates pass again.

## Changes

- `ruff check --fix`: removed 3 unused imports (F401) — `ExecutionPlan`/`ParallelGroup` in `tests/unit/test_parallel.py`, `pytest` in `tests/integration/test_execution_engine.py`
- `ruff format`: reformatted the 8 files the formatter flags (whitespace/wrapping only)

No behavior change; 62 insertions / 29 deletions across 8 files.

## Related Issue

Unblocks CI for #569 and any other open PR.

## Checklist

### Git Workflow
- [x] External contributors: Followed Fork → topic branch → upstream PR flow
- [x] Rebased on upstream/master (no conflicts)
- [x] Commit messages follow Conventional Commits

### Code Quality
- [x] Changes are limited to a single purpose (~90 line diff, purely mechanical)
- [x] Follows existing code conventions and patterns
- [x] Added appropriate tests for new features/fixes (n/a — no behavior change)
- [x] Lint/Format/Typecheck all pass (`ruff check` + `ruff format --check` verified locally)
- [ ] CI/CD pipeline succeeds (green status) — pending; note the known flaky `test_quick_execute_empty` `ZeroDivisionError` on master, fixed separately in #569

### Security
- [x] No secrets or credentials committed
- [x] No breaking changes

### Documentation
- [x] Updated documentation as needed (n/a)

## How to Test

```bash
uvx ruff check src/ tests/          # All checks passed!
uvx ruff format --check src/ tests/ # 44 files already formatted
uv run pytest                       # 135/136; the 1 failure is the pre-existing flake #569 fixes
```

## Notes

Happy to rebase this under or over #569, whichever order you prefer to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)