### PR TITLE
fix: replace broken star history chart in README

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -522,11 +522,11 @@ SuperClaude v4.2は、自律的、適応的、インテリジェントなウェ�
 
 ## ⭐ **Star履歴**
 
-<a href="https://www.star-history.com/#SuperClaude-Org/SuperClaude_Framework&Timeline">
+<a href="https://star-history.dera.page/#SuperClaude-Org/SuperClaude_Framework&Timeline">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
  </picture>
 </a>
 

--- a/README-kr.md
+++ b/README-kr.md
@@ -525,11 +525,11 @@ SuperClaude v4.2는 자율적이고 적응적이며 지능적인 웹 연구를 �
 
 ## ⭐ **Star 히스토리**
 
-<a href="https://www.star-history.com/#SuperClaude-Org/SuperClaude_Framework&Timeline">
+<a href="https://star-history.dera.page/#SuperClaude-Org/SuperClaude_Framework&Timeline">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
  </picture>
 </a>
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -522,11 +522,11 @@ SuperClaude v4.2引入了全面的深度研究能力，实现自主、自适应�
 
 ## ⭐ **Star历史**
 
-<a href="https://www.star-history.com/#SuperClaude-Org/SuperClaude_Framework&Timeline">
+<a href="https://star-history.dera.page/#SuperClaude-Org/SuperClaude_Framework&Timeline">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -560,11 +560,11 @@ This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) 
 
 ## ⭐ **Star History**
 
-<a href="https://www.star-history.com/#SuperClaude-Org/SuperClaude_Framework&Timeline">
+<a href="https://star-history.dera.page/#SuperClaude-Org/SuperClaude_Framework&Timeline">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=SuperClaude-Org/SuperClaude_Framework&type=Timeline" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart shown in the README is currently broken because the underlying provider relies on the GitHub stargazer API, which is now restricted. This change switches the chart and its wrapping link to star-history.dera.page, an alternative that uses a different data source and requires no API token.

Updates applied to README.md, README-kr.md, README-ja.md, and README-zh.md. This fix is necessary to restore the star history display.